### PR TITLE
Add company timeline page

### DIFF
--- a/public/checklist.html
+++ b/public/checklist.html
@@ -12,6 +12,7 @@
     <nav>
       <a href="/index.html">Home</a>
       <a href="/module1.html">Module 1</a>
+      <a href="/company.html">Company Info</a>
       <span id="auth"></span>
     </nav>
   </header>

--- a/public/company.html
+++ b/public/company.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Company History - AO Globe Life Training</title>
+  <link rel="stylesheet" href="/css/style.css" />
+</head>
+<body>
+  <header>
+    <img src="/img/logo.svg" alt="AO Globe Life Logo" />
+    <nav>
+      <a href="/index.html">Home</a>
+      <a href="/module1.html">Module 1</a>
+      <a href="/checklist.html">Hiring Checklist</a>
+      <a href="/company.html">Company Info</a>
+      <span id="auth"></span>
+    </nav>
+  </header>
+  <main>
+    <h1>Company History</h1>
+    <ul class="timeline">
+      <li data-year="1951">
+        American Income Life is founded by Bernard Rapoport to offer supplemental benefits for working families.
+      </li>
+      <li data-year="1994">
+        Torchmark Corporation acquires American Income Life, expanding the company's reach across the United States and Canada.
+      </li>
+      <li data-year="2019">
+        Torchmark rebrands as Globe Life, unifying its companies under a single name.
+      </li>
+      <li data-year="2024">
+        American Income Life AO announces its name change and rebrand to AO Globe Life, aligning more closely with Globe Life.
+      </li>
+      <li data-year="Today">
+        Globe Life continues to provide life and supplemental health insurance to help protect the financial future of families across North America.
+      </li>
+    </ul>
+  </main>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <script src="/js/auth.js"></script>
+</body>
+</html>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -39,3 +39,23 @@ summary {
   color: #005daa;
   font-weight: bold;
 }
+
+.timeline {
+  list-style: none;
+  padding-left: 2rem;
+  border-left: 2px solid #005daa;
+}
+
+.timeline li {
+  margin: 1rem 0;
+  position: relative;
+}
+
+.timeline li::before {
+  content: attr(data-year);
+  position: absolute;
+  left: -2.5rem;
+  top: 0;
+  font-weight: bold;
+  color: #005daa;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
     <img src="/img/logo.svg" alt="AO Globe Life Logo" />
     <nav>
       <a href="/module1.html">Module 1</a>
+      <a href="/company.html">Company Info</a>
       <a href="/checklist.html">Hiring Checklist</a>
       <span id="auth"></span>
     </nav>

--- a/public/module1.html
+++ b/public/module1.html
@@ -12,6 +12,7 @@
     <nav>
       <a href="/index.html">Home</a>
       <a href="/checklist.html">Hiring Checklist</a>
+      <a href="/company.html">Company Info</a>
       <span id="auth"></span>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- Create dedicated Company History page with timeline events from American Income Life to AO Globe Life
- Add navigation link to the new page across the site
- Style timeline component for clear chronological layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f737b9cc8325bc5f3e2b4f911005