### PR TITLE
fix: make asset paths relative for GitHub Pages

### DIFF
--- a/public/checklist.html
+++ b/public/checklist.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Hiring Checklist</title>
-  <link rel="stylesheet" href="/css/style.css" />
+  <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
   <header>
-    <img src="/img/logo.svg" alt="AO Globe Life Logo" />
+    <img src="img/logo.svg" alt="AO Globe Life Logo" />
     <nav>
-      <a href="/index.html">Home</a>
-      <a href="/module1.html">Module 1</a>
-      <a href="/company.html">Company Info</a>
+      <a href="index.html">Home</a>
+      <a href="module1.html">Module 1</a>
+      <a href="company.html">Company Info</a>
       <span id="auth"></span>
     </nav>
   </header>
@@ -43,6 +43,6 @@
     </ul>
   </main>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
-  <script src="/js/auth.js"></script>
+  <script src="js/auth.js"></script>
 </body>
 </html>

--- a/public/company.html
+++ b/public/company.html
@@ -4,16 +4,16 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Company History - AO Globe Life Training</title>
-  <link rel="stylesheet" href="/css/style.css" />
+  <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
   <header>
-    <img src="/img/logo.svg" alt="AO Globe Life Logo" />
+    <img src="img/logo.svg" alt="AO Globe Life Logo" />
     <nav>
-      <a href="/index.html">Home</a>
-      <a href="/module1.html">Module 1</a>
-      <a href="/checklist.html">Hiring Checklist</a>
-      <a href="/company.html">Company Info</a>
+      <a href="index.html">Home</a>
+      <a href="module1.html">Module 1</a>
+      <a href="checklist.html">Hiring Checklist</a>
+      <a href="company.html">Company Info</a>
       <span id="auth"></span>
     </nav>
   </header>
@@ -38,6 +38,6 @@
     </ul>
   </main>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
-  <script src="/js/auth.js"></script>
+  <script src="js/auth.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AO Globe Life Portal</title>
-  <link rel="stylesheet" href="/css/style.css" />
+  <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
   <header class="branding">
-    <img src="/img/logo.svg" alt="AO Globe Life Logo" />
-    <img src="/img/globe-life-logo.png" alt="Globe Life Logo" class="globe-logo" />
+    <img src="img/logo.svg" alt="AO Globe Life Logo" />
+    <img src="img/globe-life-logo.png" alt="Globe Life Logo" class="globe-logo" />
   </header>
   <main>
     <section id="login-section">
@@ -26,7 +26,7 @@
       <p>Part of the Globe Life family of companies providing coverage across North America.</p>
       <p id="userEmail"></p>
       <div class="menu">
-        <a href="/module1.html" class="menu-item">Training</a>
+        <a href="module1.html" class="menu-item">Training</a>
         <a href="#" class="menu-item">Agent Tools</a>
         <a href="#" class="menu-item">Management Tools</a>
       </div>
@@ -34,6 +34,6 @@
     </section>
   </main>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
-  <script src="/js/auth.js"></script>
+  <script src="js/auth.js"></script>
 </body>
 </html>

--- a/public/module1.html
+++ b/public/module1.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Module 1 - AO Globe Life Training</title>
-  <link rel="stylesheet" href="/css/style.css" />
+  <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
   <header>
-    <img src="/img/logo.svg" alt="AO Globe Life Logo" />
+    <img src="img/logo.svg" alt="AO Globe Life Logo" />
     <nav>
-      <a href="/index.html">Home</a>
-      <a href="/checklist.html">Hiring Checklist</a>
-      <a href="/company.html">Company Info</a>
+      <a href="index.html">Home</a>
+      <a href="checklist.html">Hiring Checklist</a>
+      <a href="company.html">Company Info</a>
       <span id="auth"></span>
     </nav>
   </header>
@@ -102,7 +102,7 @@
     </details>
   </main>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
-  <script src="/js/auth.js"></script>
+  <script src="js/auth.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- ensure landing page and related pages use relative asset paths so Google sign-in loads on GitHub Pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ffb499c08325aae3fa93bfe97d18