### PR TITLE
Add financial analysis popup with per-user data storage

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -112,3 +112,54 @@ summary {
 #userEmail {
   margin-top: 1rem;
 }
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  width: 90%;
+  max-width: 400px;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.modal-body label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.fa-field {
+  margin-bottom: 0.5rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.hidden {
+  display: none;
+}

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -2,6 +2,7 @@ const allowedUsers = [
   'rerhardt@ailpdx.com',
   'tmdermid@ailpdx.com'
 ];
+window.allowedUsers = allowedUsers;
 
 const CLIENT_ID = 'YOUR_GOOGLE_CLIENT_ID'; // Replace with your Google OAuth Client ID
 
@@ -18,6 +19,7 @@ function parseJwt(token) {
 }
 
 function showDashboard(email) {
+  window.loggedInUser = email;
   const loginSection = document.getElementById('login-section');
   if (loginSection) {
     loginSection.style.display = 'none';

--- a/public/js/financialAnalysis.js
+++ b/public/js/financialAnalysis.js
@@ -1,0 +1,110 @@
+const analysisFields = [
+  { id: 'income', label: 'Monthly Income' },
+  { id: 'housing', label: 'Housing' },
+  { id: 'utilities', label: 'Utilities' },
+  { id: 'transportation', label: 'Transportation' },
+  { id: 'food', label: 'Food' },
+  { id: 'insurance', label: 'Insurance' },
+  { id: 'personal', label: 'Personal' },
+  { id: 'debt', label: 'Debt' },
+  { id: 'savings', label: 'Savings' }
+];
+
+document.addEventListener('DOMContentLoaded', () => {
+  const beginBtn = document.getElementById('begin-financial-analysis');
+  const modal = document.getElementById('financialAnalysisModal');
+  const fieldsContainer = document.getElementById('faFields');
+  let currentUser = window.loggedInUser || 'unknown';
+
+  if (fieldsContainer) {
+    analysisFields.forEach(f => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'fa-field';
+      const label = document.createElement('label');
+      label.textContent = f.label;
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.id = `fa-${f.id}`;
+      label.appendChild(input);
+      wrapper.appendChild(label);
+      fieldsContainer.appendChild(wrapper);
+    });
+  }
+
+  function openModal() {
+    document.getElementById('faUser').textContent = `User: ${currentUser}`;
+    const override = document.getElementById('faUserOverride');
+    if (override && window.allowedUsers && window.allowedUsers.includes(window.loggedInUser)) {
+      override.classList.remove('hidden');
+      override.value = currentUser;
+      override.addEventListener('change', () => {
+        currentUser = override.value.trim() || window.loggedInUser || 'unknown';
+        document.getElementById('faUser').textContent = `User: ${currentUser}`;
+        loadData();
+      });
+    }
+    modal.classList.remove('hidden');
+    loadData();
+  }
+
+  function closeModal() {
+    modal.classList.add('hidden');
+  }
+
+  function loadData() {
+    const key = `financialAnalysis_${currentUser}`;
+    const saved = localStorage.getItem(key);
+    if (saved) {
+      const obj = JSON.parse(saved);
+      document.getElementById('faDate').value = obj.dateCompleted || new Date().toISOString().split('T')[0];
+      analysisFields.forEach(f => {
+        document.getElementById(`fa-${f.id}`).value = obj.fields[f.id] || '';
+      });
+    } else {
+      document.getElementById('faDate').value = new Date().toISOString().split('T')[0];
+      analysisFields.forEach(f => {
+        document.getElementById(`fa-${f.id}`).value = '';
+      });
+    }
+  }
+
+  function saveData() {
+    const dateVal = document.getElementById('faDate').value;
+    const d = dateVal ? new Date(dateVal) : new Date();
+    const data = {
+      userId: currentUser,
+      dateCompleted: dateVal,
+      month: d.getMonth() + 1,
+      year: d.getFullYear(),
+      fields: {}
+    };
+    analysisFields.forEach(f => {
+      data.fields[f.id] = document.getElementById(`fa-${f.id}`).value;
+    });
+    localStorage.setItem(`financialAnalysis_${currentUser}`, JSON.stringify(data));
+    closeModal();
+  }
+
+  function generatePdf() {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    let y = 10;
+    doc.text(`Financial Analysis - ${document.getElementById('faDate').value}`, 10, y);
+    y += 10;
+    analysisFields.forEach(f => {
+      const val = document.getElementById(`fa-${f.id}`).value;
+      doc.text(`${f.label}: ${val}`, 10, y);
+      y += 10;
+    });
+    doc.save('financial_analysis.pdf');
+  }
+
+  const closeBtn = document.getElementById('faClose');
+  const saveBtn = document.getElementById('faSave');
+  const pdfBtn = document.getElementById('faPdf');
+
+  if (beginBtn) beginBtn.addEventListener('click', openModal);
+  if (closeBtn) closeBtn.addEventListener('click', closeModal);
+  if (saveBtn) saveBtn.addEventListener('click', saveData);
+  if (pdfBtn) pdfBtn.addEventListener('click', generatePdf);
+});

--- a/public/module1.html
+++ b/public/module1.html
@@ -42,7 +42,10 @@
         </ol>
         <h4>Tasks</h4>
         <ul>
-          <li><strong>Print two copies of the 1a Financial Analysis Sheet.</strong> Begin now so you can record recurring expenses you might overlook, such as haircuts. Exact amounts are not required; we will use your approximate monthly income requirement to build a reverse budget and determine the activity needed to reach your goals.</li>
+          <li>
+            <strong>Complete the 1a Financial Analysis.</strong> Begin now so you can record recurring expenses you might overlook, such as haircuts. Exact amounts are not required; we will use your approximate monthly income requirement to build a reverse budget and determine the activity needed to reach your goals.
+            <button id="begin-financial-analysis" type="button">Begin Financial Analysis</button>
+          </li>
           <li><strong>Add an alarm for the Professional Growth and Personal Development meeting.</strong> This meeting occurs every Friday at 11:00 a.m. Pacific. Set a reminder for 10 minutes beforehand and add it to your work calendar as a weekly recurring event.</li>
         </ul>
         <h4>Expectations</h4>
@@ -101,8 +104,28 @@
 
     </details>
   </main>
+  <div id="financialAnalysisModal" class="modal hidden">
+    <div class="modal-content">
+      <div class="modal-header">
+        <span id="faUser"></span>
+        <input type="text" id="faUserOverride" class="hidden" placeholder="User ID" />
+        <button id="faClose" type="button">&times;</button>
+      </div>
+      <div class="modal-body">
+        <label>Date: <input type="date" id="faDate" /></label>
+        <div id="faFields"></div>
+        <div class="modal-actions">
+          <button id="faPdf" type="button">PDF</button>
+          <button id="faSave" type="button">Save & Exit</button>
+        </div>
+      </div>
+    </div>
+  </div>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script src="js/auth.js"></script>
+  <script src="user_data/financialAnalysisData.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="js/financialAnalysis.js"></script>
 </body>
 </html>
 

--- a/public/user_data/financialAnalysisData.js
+++ b/public/user_data/financialAnalysisData.js
@@ -1,0 +1,21 @@
+const financialAnalysisData = {
+  userId: '',
+  dateCompleted: '',
+  month: '',
+  year: '',
+  fields: {
+    income: '',
+    housing: '',
+    utilities: '',
+    transportation: '',
+    food: '',
+    insurance: '',
+    personal: '',
+    debt: '',
+    savings: ''
+  }
+};
+
+if (typeof window !== 'undefined') {
+  window.financialAnalysisData = financialAnalysisData;
+}


### PR DESCRIPTION
## Summary
- Replace PDF printing task with "Begin Financial Analysis" button and modal for data entry.
- Introduce financial analysis data template and per-user local storage with PDF export.
- Expose logged-in user globally for reuse across modules and add modal styling.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c701ea16b08325a524ac01940ef298