### PR TITLE
feat: add configurable Google sign-in client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 cert/server.*
 
+public/js/config.js

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains a training and resource hub for AO Globe Life agents an
    ```sh
    npm install
    ```
-2. Replace the `CLIENT_ID` constant in `public/js/auth.js` with your Google OAuth Client ID.
+2. Copy `public/js/config.example.js` to `public/js/config.js` and replace the placeholder with your Google OAuth Client ID.
 3. (Optional) Update the `allowedUsers` array in `public/js/auth.js` to restrict access.
 4. Deploy to GitHub Pages:
    ```sh
@@ -21,3 +21,10 @@ This repository contains a training and resource hub for AO Globe Life agents an
    ```
 
 The site serves static content from `public/` and requires no server beyond GitHub Pages.
+
+## Google Sign-In Troubleshooting
+
+If you encounter a 400 error when attempting to sign in with Google, it usually means the OAuth client is misconfigured. Verify that:
+
+- `public/js/config.js` contains your actual Google OAuth Client ID.
+- The domain serving the site is listed under **Authorized JavaScript origins** in the Google Cloud Console.

--- a/public/checklist.html
+++ b/public/checklist.html
@@ -43,6 +43,7 @@
     </ul>
   </main>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <script src="js/config.js"></script>
   <script src="js/auth.js"></script>
 </body>
 </html>

--- a/public/company.html
+++ b/public/company.html
@@ -38,6 +38,7 @@
     </ul>
   </main>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <script src="js/config.js"></script>
   <script src="js/auth.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,7 @@
     </section>
   </main>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <script src="js/config.js"></script>
   <script src="js/auth.js"></script>
 </body>
 </html>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -4,7 +4,8 @@ const allowedUsers = [
 ];
 window.allowedUsers = allowedUsers;
 
-const CLIENT_ID = 'YOUR_GOOGLE_CLIENT_ID'; // Replace with your Google OAuth Client ID
+// Client ID is provided via public/js/config.js which sets window.GOOGLE_CLIENT_ID
+const CLIENT_ID = window.GOOGLE_CLIENT_ID || '';
 
 function parseJwt(token) {
   const base64Url = token.split('.')[1];
@@ -59,6 +60,14 @@ function handleCredentialResponse(response) {
 }
 
 function initGoogle() {
+  if (!CLIENT_ID) {
+    console.warn('Google OAuth Client ID not set. See config.js.');
+    const buttonEl = document.getElementById('g_id_button');
+    if (buttonEl) {
+      buttonEl.innerHTML = '<p>Google Sign-In unavailable</p>';
+    }
+    return;
+  }
   if (localStorage.getItem('rememberedUser')) {
     showDashboard(localStorage.getItem('rememberedUser'));
     return;

--- a/public/js/config.example.js
+++ b/public/js/config.example.js
@@ -1,0 +1,2 @@
+// Rename this file to config.js and replace the placeholder with your Google OAuth Client ID.
+window.GOOGLE_CLIENT_ID = 'YOUR_GOOGLE_CLIENT_ID';

--- a/public/module1.html
+++ b/public/module1.html
@@ -122,6 +122,7 @@
     </div>
   </div>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <script src="js/config.js"></script>
   <script src="js/auth.js"></script>
   <script src="user_data/financialAnalysisData.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>


### PR DESCRIPTION
## Summary
- allow configuring Google OAuth client ID via `public/js/config.js`
- load config before auth code and warn when ID is missing
- document setup and troubleshooting steps for Google sign-in

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c70b4c01988325b65f1798c6cdd735