### PR TITLE
Remove unused passkey/2FA options and improve Google sign-in guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ If you encounter a 400 error when attempting to sign in with Google, it usually 
 
 - `public/js/config.js` contains your actual Google OAuth Client ID.
 - The domain serving the site is listed under **Authorized JavaScript origins** in the Google Cloud Console.
+
+Refer to Google's documentation for additional setup details:
+https://developers.google.com/identity/sign-in/web/sign-in

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -77,14 +77,6 @@ summary {
   margin-top: 1rem;
 }
 
-.alt-options {
-  margin-top: 1rem;
-}
-
-.alt-options button {
-  margin: 0 0.5rem;
-}
-
 .menu {
   display: flex;
   justify-content: center;

--- a/public/index.html
+++ b/public/index.html
@@ -16,10 +16,6 @@
       <h1>Sign In</h1>
       <div id="g_id_button"></div>
       <label class="remember"><input type="checkbox" id="rememberMe" /> Remember me</label>
-      <div class="alt-options">
-        <button id="2faBtn" type="button">Use 2FA</button>
-        <button id="passkeyBtn" type="button">Use Passkey</button>
-      </div>
     </section>
     <section id="dashboard" style="display:none;">
       <h1>AO Globe Life</h1>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -64,7 +64,7 @@ function initGoogle() {
     console.warn('Google OAuth Client ID not set. See config.js.');
     const buttonEl = document.getElementById('g_id_button');
     if (buttonEl) {
-      buttonEl.innerHTML = '<p>Google Sign-In unavailable</p>';
+      buttonEl.innerHTML = '<p>Google Sign-In unavailable. See <a href="https://developers.google.com/identity/sign-in/web/sign-in">setup instructions</a>.</p>';
     }
     return;
   }
@@ -87,16 +87,4 @@ function initGoogle() {
 
 window.addEventListener('load', () => {
   initGoogle();
-  const twoFa = document.getElementById('2faBtn');
-  if (twoFa) {
-    twoFa.addEventListener('click', () => {
-      alert('2FA is required through your Google account.');
-    });
-  }
-  const passkey = document.getElementById('passkeyBtn');
-  if (passkey) {
-    passkey.addEventListener('click', () => {
-      alert('Passkey login will use your device credentials.');
-    });
-  }
 });


### PR DESCRIPTION
## Summary
- Drop passkey and 2FA buttons and related styles and scripts.
- Link to Google sign-in docs when Client ID is missing.
- Reference Google documentation in troubleshooting guide.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7140313e8832591131e5f8fca5b82