### PR TITLE
Add email/password login and user profile

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -72,6 +72,24 @@ summary {
   margin-top: 2rem;
 }
 
+#emailLoginForm {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+#emailLoginForm input {
+  padding: 0.5rem;
+  width: 100%;
+  max-width: 300px;
+}
+
+#emailLoginForm button {
+  padding: 0.5rem 1rem;
+}
+
 .remember {
   display: block;
   margin-top: 1rem;

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,11 @@
   <main>
     <section id="login-section">
       <h1>Sign In</h1>
+      <form id="emailLoginForm">
+        <input type="email" id="email" placeholder="Email" required />
+        <input type="password" id="password" placeholder="Password" required />
+        <button type="submit">Sign In</button>
+      </form>
       <div id="g_id_button"></div>
       <label class="remember"><input type="checkbox" id="rememberMe" /> Remember me</label>
     </section>
@@ -31,6 +36,7 @@
   </main>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script src="js/config.js"></script>
+  <script src="user_data/users.js"></script>
   <script src="js/auth.js"></script>
 </body>
 </html>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,7 +1,5 @@
-const allowedUsers = [
-  'rerhardt@ailpdx.com',
-  'tmdermid@ailpdx.com'
-];
+const users = window.users || [];
+const allowedUsers = users.map(user => user.email);
 window.allowedUsers = allowedUsers;
 
 // Client ID is provided via public/js/config.js which sets window.GOOGLE_CLIENT_ID
@@ -42,6 +40,24 @@ function showDashboard(email) {
         initGoogle();
       });
     }
+  }
+}
+
+function handleEmailLogin(event) {
+  event.preventDefault();
+  const emailInput = document.getElementById('email');
+  const passwordInput = document.getElementById('password');
+  if (!emailInput || !passwordInput) return;
+  const email = emailInput.value;
+  const password = passwordInput.value;
+  const user = users.find(u => u.email === email && u.password === password);
+  if (user) {
+    if (document.getElementById('rememberMe').checked) {
+      localStorage.setItem('rememberedUser', email);
+    }
+    showDashboard(email);
+  } else {
+    alert('Invalid email or password');
   }
 }
 
@@ -86,5 +102,9 @@ function initGoogle() {
 }
 
 window.addEventListener('load', () => {
+  const form = document.getElementById('emailLoginForm');
+  if (form) {
+    form.addEventListener('submit', handleEmailLogin);
+  }
   initGoogle();
 });

--- a/public/user_data/users.js
+++ b/public/user_data/users.js
@@ -1,0 +1,27 @@
+const users = [
+  {
+    email: 'rerhardt@ailpdx.com',
+    password: '1qaz2wsx!QAZ@WSX',
+    profile: {
+      privileges: ['Administrator', 'Manager'],
+      contract: 'SA - Supervising Agent',
+      sga: 'AO',
+      mga: 'Chris La Fond',
+      upline: 'Tabitha McDermid',
+      trainingStage: 'Complete',
+      phoneNumber: '503-381-3341',
+      altEmail: 'russellerhardt@aoglobelife.com',
+      residentState: 'Oregon'
+    }
+  },
+  {
+    email: 'tmdermid@ailpdx.com',
+    password: '',
+    profile: {}
+  }
+];
+
+if (typeof window !== 'undefined') {
+  window.users = users;
+}
+


### PR DESCRIPTION
## Summary
- add email/password sign-in form above existing Google login
- load user profiles and validate credentials for email login
- include rerhardt@ailpdx.com profile with required details

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c71d396b0c83258ac2a272052f30e4