### PR TITLE
Improve login feedback and redirect after sign-in

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -95,6 +95,11 @@ summary {
   margin-top: 1rem;
 }
 
+.error {
+  color: red;
+  margin-top: 1rem;
+}
+
 .menu {
   display: flex;
   justify-content: center;

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
       </form>
       <div id="g_id_button"></div>
       <label class="remember"><input type="checkbox" id="rememberMe" /> Remember me</label>
+      <p id="loginError" class="error"></p>
     </section>
     <section id="dashboard" style="display:none;">
       <h1>AO Globe Life</h1>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -48,29 +48,39 @@ function handleEmailLogin(event) {
   const emailInput = document.getElementById('email');
   const passwordInput = document.getElementById('password');
   if (!emailInput || !passwordInput) return;
-  const email = emailInput.value;
+  const email = emailInput.value.trim();
   const password = passwordInput.value;
-  const user = users.find(u => u.email === email && u.password === password);
-  if (user) {
-    if (document.getElementById('rememberMe').checked) {
-      localStorage.setItem('rememberedUser', email);
-    }
-    showDashboard(email);
-  } else {
-    alert('Invalid email or password');
+  const errorEl = document.getElementById('loginError');
+  const user = users.find(u => u.email === email);
+  if (!user) {
+    if (errorEl) errorEl.textContent = 'Unknown user';
+    return;
   }
+  if (user.password !== password) {
+    if (errorEl) errorEl.textContent = 'Invalid email or password';
+    return;
+  }
+  if (errorEl) errorEl.textContent = '';
+  if (document.getElementById('rememberMe').checked) {
+    localStorage.setItem('rememberedUser', email);
+  }
+  showDashboard(email);
+  window.location.href = 'module1.html';
 }
 
 function handleCredentialResponse(response) {
   const data = parseJwt(response.credential);
   const email = data.email;
+  const errorEl = document.getElementById('loginError');
   if (allowedUsers.includes(email)) {
     if (document.getElementById('rememberMe').checked) {
       localStorage.setItem('rememberedUser', email);
     }
+    if (errorEl) errorEl.textContent = '';
     showDashboard(email);
+    window.location.href = 'module1.html';
   } else {
-    alert('Unauthorized user');
+    if (errorEl) errorEl.textContent = 'Unknown user';
     google.accounts.id.disableAutoSelect();
   }
 }


### PR DESCRIPTION
## Summary
- display specific message when login credentials are unknown or invalid
- add error styling and on-page error container
- redirect authenticated users to Module 1 page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c721ceb9888325909506377a426fbd