### PR TITLE
Add Globe Life Field popup with embedded video

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -437,6 +437,7 @@
           <img src="https://upload.wikimedia.org/wikipedia/en/thumb/5/5c/FC_Dallas_logo.svg/320px-FC_Dallas_logo.svg.png" alt="FC Dallas" />
           <img src="https://upload.wikimedia.org/wikipedia/en/thumb/9/94/Allen_Americans_logo.svg/320px-Allen_Americans_logo.svg.png" alt="Allen Americans" />
         </div>
+        <div class="chips"><div class="chip" data-pop="globe-life-field">Explore Globe Life Field</div></div>
         <p class="source">Check out <a href="https://home.globelifeinsurance.com/about/globe-life-field">Globe Life Field</a> and <a href="https://home.globelifeinsurance.com/press-releases">Press releases</a>.</p>
       </div>
     </article>
@@ -739,6 +740,20 @@
       <p class="source">Check out <a href="https://home.globelifeinsurance.com/about">Globe Life - About</a>.</p>
     </div>
 
+    <div class="popup" id="pop-globe-life-field">
+      <h4>Inside Globe Life Field</h4>
+      <p>Globe Life Field in Arlington delivers a climate-controlled, retractable-roof home for the Texas Rangers with the flexibility to host baseball, concerts, and marquee events year-round.</p>
+      <ul>
+        <li>1.8M-square-foot ballpark with a 5.5-acre retractable roof and operable outfield doors for open-air game days.</li>
+        <li>Seats approximately 40,300 fans with 360-degree concourses, premium clubs, and Texas Live! entertainment next door.</li>
+        <li>Designed for player wellness with advanced training facilities, natural light, and modern clubhouse spaces.</li>
+      </ul>
+      <div style="margin:12px 0;">
+        <iframe title="Globe Life Field tour" src="https://player.vimeo.com/video/852960498?h=8fceda4be4" width="100%" height="320" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" allowfullscreen></iframe>
+      </div>
+      <p class="source">Explore more at <a href="https://home.globelifeinsurance.com/about/globe-life-field">Globe Life Field - Globe Life</a> and <a href="https://globelifefield.com/">globelifefield.com</a>.</p>
+    </div>
+
     <div class="popup" id="pop-financial-profile">
       <h4>Financial profile</h4>
       <ul>
@@ -824,6 +839,7 @@
       'community-recent':'pop-community-recent',
       'grants-program':'pop-grants-program',
       'globe-life':'pop-globe-life',
+      'globe-life-field':'pop-globe-life-field',
       'financial-profile':'pop-financial-profile',
       'who-we-work-with':'pop-who-we-work-with',
       'geo-reach':'pop-geo-reach',


### PR DESCRIPTION
## Summary
- add a "Explore Globe Life Field" chip to the brand partnerships timeline entry
- create a Globe Life Field popup that highlights stadium features and links to official resources
- embed the official Globe Life Field Vimeo tour video inside the new popup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d434b412348325b9b512daf2ede147