### PR TITLE
Unify navigation and refresh company overview

### DIFF
--- a/public/checklist.html
+++ b/public/checklist.html
@@ -4,17 +4,25 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Hiring Checklist</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/nav.css" />
 </head>
 <body>
-  <header>
-    <img src="img/logo.svg" alt="AO Globe Life Logo" />
-    <nav>
-      <a href="index.html">Home</a>
-      <a href="module1.html">Module 1</a>
-      <a href="company.html">Company Info</a>
-      <span id="auth"></span>
+  <header class="site-header">
+    <a class="site-logo" href="index.html" aria-label="AO Globe Life home">
+      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+    </a>
+    <nav class="nav-links" aria-label="Main">
+      <a href="history.html">History &amp; Timeline</a>
+      <a href="community.html">Community</a>
+      <a href="company.html">Company</a>
+      <a href="module1.html">Training</a>
+      <a href="contact.html">Contact</a>
     </nav>
+    <span id="auth" class="auth-status"></span>
   </header>
   <main>
     <h1>Hiring Process Checklist</h1>

--- a/public/community.html
+++ b/public/community.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/nav.css" />
   <style>
     :root {
       --ao-blue: #0a3e7a;
@@ -30,42 +31,19 @@
       flex-direction: column;
     }
 
-    header {
+    .site-header {
+      width: min(1100px, 92vw);
+      margin: clamp(16px, 5vw, 32px) auto 0;
       padding: 24px clamp(16px, 6vw, 72px) 16px;
       display: flex;
       flex-wrap: wrap;
       align-items: center;
-      justify-content: space-between;
+      justify-content: center;
       gap: 18px;
     }
 
-    header img {
-      height: 48px;
-      width: auto;
-    }
-
-    nav {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-    }
-
-    nav a {
-      text-decoration: none;
-      font-weight: 600;
-      letter-spacing: 0.2px;
-      color: #fff;
-      background: linear-gradient(120deg, var(--ao-blue), var(--ao-green));
-      padding: 10px 18px;
-      border-radius: 999px;
-      box-shadow: 0 10px 24px rgba(10, 62, 122, 0.16);
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    nav a:hover,
-    nav a:focus-visible {
-      transform: translateY(-1px);
-      box-shadow: 0 14px 28px rgba(10, 62, 122, 0.22);
+    .site-header .nav-links {
+      justify-content: center;
     }
 
     main {
@@ -149,12 +127,15 @@
   </style>
 </head>
 <body>
-  <header>
-    <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
-    <nav aria-label="Site">
-      <a href="index.html">Home</a>
-      <a href="history.html">History</a>
+  <header class="site-header">
+    <a class="site-logo" href="index.html" aria-label="AO Globe Life home">
+      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+    </a>
+    <nav class="nav-links" aria-label="Main">
+      <a href="history.html">History &amp; Timeline</a>
+      <a href="community.html" aria-current="page">Community</a>
       <a href="company.html">Company</a>
+      <a href="module1.html">Training</a>
       <a href="contact.html">Contact</a>
     </nav>
   </header>

--- a/public/company.html
+++ b/public/company.html
@@ -3,39 +3,87 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Company History - AO Globe Life Training</title>
+  <title>Company Overview - AO Globe Life Training</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/nav.css" />
 </head>
 <body>
-  <header>
-    <img src="img/logo.svg" alt="AO Globe Life Logo" />
-    <nav>
-      <a href="index.html">Home</a>
-      <a href="module1.html">Module 1</a>
-      <a href="checklist.html">Hiring Checklist</a>
-      <a href="company.html">Company Info</a>
-      <span id="auth"></span>
+  <header class="site-header">
+    <a class="site-logo" href="index.html" aria-label="AO Globe Life home">
+      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+    </a>
+    <nav class="nav-links" aria-label="Main">
+      <a href="history.html">History &amp; Timeline</a>
+      <a href="community.html">Community</a>
+      <a href="company.html" aria-current="page">Company</a>
+      <a href="module1.html">Training</a>
+      <a href="contact.html">Contact</a>
     </nav>
+    <span id="auth" class="auth-status"></span>
   </header>
   <main>
-    <h1>Company History</h1>
-    <ul class="timeline">
-      <li data-year="1951">
-        American Income Life is founded by Bernard Rapoport to offer supplemental benefits for working families.
-      </li>
-      <li data-year="1994">
-        Torchmark Corporation acquires American Income Life, expanding the company's reach across the United States and Canada.
-      </li>
-      <li data-year="2019">
-        Torchmark rebrands as Globe Life, unifying its companies under a single name.
-      </li>
-      <li data-year="2024">
-        American Income Life AO announces its name change and rebrand to AO Globe Life, aligning more closely with Globe Life.
-      </li>
-      <li data-year="Today">
-        Globe Life continues to provide life and supplemental health insurance to help protect the financial future of families across North America.
-      </li>
-    </ul>
+    <div class="page-hero">
+      <h1>AO Globe Life Company Overview</h1>
+      <p class="intro">From our labor roots to today's national reach, AO Globe Life connects the strength of Globe Life with a
+        mission to protect working families and develop future leaders.</p>
+    </div>
+
+    <section class="info-grid two-column" aria-label="Company highlights">
+      <article class="info-card">
+        <h2>Who we are</h2>
+        <p>AO Globe Life is the largest distribution of Globe Life’s American Income Life division. We are a
+          leadership-driven agency system focused on serving union members, associations, and the communities we call
+          home.</p>
+        <ul>
+          <li>Founded on the principle of protecting working families with union-label service.</li>
+          <li>Licensed in 49 states, Washington, D.C., Canada, and New Zealand through the American Income Life brand.</li>
+          <li>Backed by Globe Life Inc. (NYSE: GL) with 17M+ policies and A or higher ratings for more than four decades.</li>
+        </ul>
+      </article>
+
+      <article class="info-card">
+        <h2>Culture &amp; leadership</h2>
+        <p>We cultivate leaders through mentorship, field training, and performance-driven advancement so every agent
+          can grow a career with impact.</p>
+        <ul>
+          <li>One-on-one mentorship and weekly leadership labs for new agents.</li>
+          <li>Business Builder Pathway outlining the milestones to agency leadership.</li>
+          <li>Recognition programs, regional summits, and annual conventions that celebrate results and service.</li>
+        </ul>
+      </article>
+
+      <article class="info-card">
+        <h2>How we serve</h2>
+        <p>Our teams partner with labor unions, associations, and local organizations to expand access to supplemental
+          protection and deliver value beyond the policy.</p>
+        <ul>
+          <li>Strike relief funds, scholarship programs, and community grants in partnership with unions and civic groups.</li>
+          <li>Customized benefits for members of the IAFF, IBEW, USW, CWA, AFGE, FOP, NALC, and more.</li>
+          <li>Dedicated outreach for veterans, first responders, and working families navigating financial uncertainty.</li>
+        </ul>
+      </article>
+
+      <article class="info-card">
+        <h2>Tools &amp; resources</h2>
+        <p>AO Globe Life invests in technology and training so agents can deliver a consistent, high-quality experience
+          virtually or in person.</p>
+        <ul>
+          <li>Digital presentations, quoting tools, and integrated e-applications for streamlined appointments.</li>
+          <li>Dedicated support teams that provide onboarding, compliance guidance, and continuing education.</li>
+          <li>Community of practice channels for sharing scripts, best practices, and referral strategies.</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="timeline-callout" aria-labelledby="timeline-callout-title">
+      <h2 id="timeline-callout-title">Explore our detailed history &amp; timeline</h2>
+      <p>We have consolidated the AO Globe Life timeline into a single immersive experience featuring milestones,
+        partnerships, and interactive stories.</p>
+      <a href="history.html">View the History &amp; Timeline</a>
+    </section>
   </main>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script src="js/config.js"></script>

--- a/public/contact.html
+++ b/public/contact.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/nav.css" />
   <style>
     :root {
       --ao-blue: #0a3e7a;
@@ -30,42 +31,19 @@
       flex-direction: column;
     }
 
-    header {
+    .site-header {
+      width: min(1100px, 92vw);
+      margin: clamp(16px, 5vw, 32px) auto 0;
       padding: 24px clamp(16px, 6vw, 72px) 16px;
       display: flex;
       flex-wrap: wrap;
       align-items: center;
-      justify-content: space-between;
+      justify-content: center;
       gap: 18px;
     }
 
-    header img {
-      height: 48px;
-      width: auto;
-    }
-
-    nav {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-    }
-
-    nav a {
-      text-decoration: none;
-      font-weight: 600;
-      letter-spacing: 0.2px;
-      color: #fff;
-      background: linear-gradient(120deg, var(--ao-blue), var(--ao-green));
-      padding: 10px 18px;
-      border-radius: 999px;
-      box-shadow: 0 10px 24px rgba(10, 62, 122, 0.16);
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    nav a:hover,
-    nav a:focus-visible {
-      transform: translateY(-1px);
-      box-shadow: 0 14px 28px rgba(10, 62, 122, 0.22);
+    .site-header .nav-links {
+      justify-content: center;
     }
 
     main {
@@ -138,13 +116,16 @@
   </style>
 </head>
 <body>
-  <header>
-    <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
-    <nav aria-label="Site">
-      <a href="index.html">Home</a>
-      <a href="history.html">History</a>
+  <header class="site-header">
+    <a class="site-logo" href="index.html" aria-label="AO Globe Life home">
+      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+    </a>
+    <nav class="nav-links" aria-label="Main">
+      <a href="history.html">History &amp; Timeline</a>
       <a href="community.html">Community</a>
       <a href="company.html">Company</a>
+      <a href="module1.html">Training</a>
+      <a href="contact.html" aria-current="page">Contact</a>
     </nav>
   </header>
   <main>

--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -1,0 +1,77 @@
+:root {
+  --ao-blue: #0a3e7a;
+  --ao-green: #00a870;
+  --ink: #1f2937;
+  --muted: #6b7280;
+}
+
+.site-header {
+  width: min(1080px, 92vw);
+  margin: clamp(16px, 5vw, 32px) auto 0;
+  padding: 24px clamp(16px, 6vw, 72px) 16px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(12px, 4vw, 24px);
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.site-logo img {
+  height: clamp(40px, 6vw, 56px);
+  width: auto;
+  filter: drop-shadow(0 8px 20px rgba(10, 62, 122, 0.14));
+}
+
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 14px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.nav-links a {
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  color: #fff;
+  background: linear-gradient(120deg, var(--ao-blue), var(--ao-green));
+  padding: 12px 22px;
+  border-radius: 999px;
+  box-shadow: 0 12px 26px rgba(10, 62, 122, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.nav-links a:hover,
+.nav-links a:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px rgba(10, 62, 122, 0.22);
+}
+
+.nav-links a:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+}
+
+.auth-status {
+  font-weight: 600;
+  color: var(--ink);
+  margin-left: auto;
+}
+
+@media (max-width: 640px) {
+  .site-header {
+    justify-content: center;
+  }
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,70 +1,40 @@
+:root {
+  --ao-blue: #0a3e7a;
+  --ao-green: #00a870;
+  --ink: #1f2937;
+  --muted: #6b7280;
+  --surface: rgba(255, 255, 255, 0.88);
+}
+
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
   margin: 0;
-  background-color: #f5f7fa;
-  color: #333;
+  background: linear-gradient(180deg, #f7f9fc 0%, #f0f6ff 45%, #f7f9fc 100%);
+  color: var(--ink);
 }
-header {
-  background-color: #005daa;
-  color: white;
-  padding: 1rem;
-  display: flex;
-  align-items: center;
-}
-header img {
-  height: 40px;
-  margin-right: 1rem;
-}
-nav a {
-  color: white;
-  margin-right: 1rem;
-  text-decoration: none;
-  font-weight: bold;
-}
+
 main {
-  padding: 1rem 2rem;
+  width: min(1080px, 92vw);
+  margin: 0 auto 72px;
+  padding: clamp(24px, 5vw, 36px) clamp(16px, 6vw, 48px);
+  background: var(--surface);
+  border-radius: 24px;
+  box-shadow: 0 24px 48px rgba(10, 62, 122, 0.12);
+  border: 1px solid rgba(10, 62, 122, 0.08);
 }
 h1, h2, h3 {
-  color: #005daa;
+  color: var(--ao-blue);
 }
 .checkbox-list li {
   list-style: none;
   margin-bottom: 0.5rem;
 }
-details {
   margin-bottom: 1rem;
 }
 summary {
   cursor: pointer;
   color: #005daa;
   font-weight: bold;
-}
-
-.timeline {
-  list-style: none;
-  padding-left: 2rem;
-  border-left: 2px solid #005daa;
-}
-
-.timeline li {
-  margin: 1rem 0;
-  position: relative;
-}
-
-.timeline li::before {
-  content: attr(data-year);
-  position: absolute;
-  left: -2.5rem;
-  top: 0;
-  font-weight: bold;
-  color: #005daa;
-}
-.branding {
-  justify-content: center;
-}
-
-.globe-logo {
-  height: 40px;
 }
 
 #login-section {
@@ -177,4 +147,96 @@ summary {
 
 .hidden {
   display: none;
+}
+
+.page-hero {
+  text-align: left;
+  margin-bottom: clamp(24px, 6vw, 40px);
+}
+
+.page-hero h1 {
+  margin-bottom: 12px;
+  font-size: clamp(2rem, 4vw, 2.6rem);
+}
+
+.page-hero .intro {
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.info-grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 760px) {
+  .info-grid.two-column {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.info-card {
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 20px;
+  padding: clamp(20px, 3vw, 28px);
+  box-shadow: 0 20px 44px rgba(10, 62, 122, 0.14);
+  border: 1px solid rgba(10, 62, 122, 0.08);
+}
+
+.info-card h2 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.info-card p {
+  margin: 0 0 12px;
+  line-height: 1.6;
+}
+
+.info-card ul {
+  margin: 0 0 0 18px;
+  padding: 0;
+  line-height: 1.6;
+}
+
+.timeline-callout {
+  margin-top: clamp(32px, 8vw, 56px);
+  padding: clamp(24px, 6vw, 36px);
+  background: linear-gradient(120deg, rgba(10, 62, 122, 0.12), rgba(0, 168, 112, 0.12));
+  border-radius: 24px;
+  border: 1px solid rgba(10, 62, 122, 0.12);
+  text-align: center;
+}
+
+.timeline-callout h2 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.timeline-callout p {
+  margin: 0 0 18px;
+  color: var(--muted);
+}
+
+.timeline-callout a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 24px;
+  border-radius: 999px;
+  background: linear-gradient(120deg, var(--ao-blue), var(--ao-green));
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  box-shadow: 0 16px 32px rgba(10, 62, 122, 0.16);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.timeline-callout a:hover,
+.timeline-callout a:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 36px rgba(10, 62, 122, 0.2);
 }

--- a/public/history.html
+++ b/public/history.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/nav.css" />
   <meta name="color-scheme" content="light dark">
   <meta charset="UTF-8" />
   <title>AO Globe Life – Comprehensive Visual Timeline</title>
@@ -28,6 +29,15 @@
     * { box-sizing: border-box; }
     body { font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; margin: 0; background:#f7f9fc; color: var(--ink); }
     header { padding: 28px 16px 0; text-align: center; }
+    .global-nav {
+      width: min(1100px, 92vw);
+      margin: clamp(16px, 5vw, 32px) auto 0;
+      justify-content: center;
+      gap: 18px;
+    }
+    .global-nav .nav-links {
+      justify-content: center;
+    }
     h1 { margin: 0 0 6px; color: var(--brand); font-size: 28px; }
     .subtitle { color: var(--muted); font-size: 14px; margin-bottom: 8px; }
 
@@ -285,6 +295,18 @@
 </style>
 </head>
 <body>
+  <div class="site-header global-nav">
+    <a class="site-logo" href="index.html" aria-label="AO Globe Life home">
+      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+    </a>
+    <nav class="nav-links" aria-label="Main">
+      <a href="history.html" aria-current="page">History &amp; Timeline</a>
+      <a href="community.html">Community</a>
+      <a href="company.html">Company</a>
+      <a href="module1.html">Training</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </div>
   <div class="layout-grid">
     <nav class="primary-menu" aria-label="Section navigation">
       <button class="menu-button" type="button" aria-expanded="false" aria-haspopup="true" aria-controls="primaryMenuList">

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/nav.css" />
   <style>
     :root {
       --ao-blue: #0a3e7a;
@@ -51,32 +52,6 @@
       filter: drop-shadow(0 8px 20px rgba(10, 62, 122, 0.14));
     }
 
-    .nav-links {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 14px;
-      padding: 0 24px 32px;
-    }
-
-    .nav-links a {
-      text-decoration: none;
-      font-weight: 600;
-      letter-spacing: 0.2px;
-      color: #fff;
-      background: linear-gradient(120deg, var(--ao-blue), var(--ao-green));
-      padding: 12px 22px;
-      border-radius: 999px;
-      box-shadow: 0 12px 26px rgba(10, 62, 122, 0.18);
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    .nav-links a:hover,
-    .nav-links a:focus-visible {
-      transform: translateY(-2px);
-      box-shadow: 0 16px 28px rgba(10, 62, 122, 0.22);
-    }
-
     .tagline {
       max-width: 520px;
       text-align: center;
@@ -84,6 +59,10 @@
       font-size: 0.95rem;
       line-height: 1.6;
       padding: 0 24px;
+    }
+
+    body > nav.nav-links {
+      padding: 0 24px 32px;
     }
 
     @media (max-width: 540px) {
@@ -104,7 +83,7 @@
   </div>
   <p class="tagline">Explore the history, community outreach, and opportunities that define AO Globe Life.</p>
   <nav class="nav-links" aria-label="Main">
-    <a href="history.html">History</a>
+    <a href="history.html">History &amp; Timeline</a>
     <a href="community.html">Community</a>
     <a href="company.html">Company</a>
     <a href="module1.html">Training</a>

--- a/public/module1.html
+++ b/public/module1.html
@@ -4,19 +4,28 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Module 1 - AO Globe Life Training</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/nav.css" />
 </head>
 <body>
-  <header>
-    <img src="img/logo.svg" alt="AO Globe Life Logo" />
-    <nav>
-      <a href="index.html">Home</a>
-      <a href="checklist.html">Hiring Checklist</a>
-      <a href="company.html">Company Info</a>
-      <span id="auth"></span>
+  <header class="site-header">
+    <a class="site-logo" href="index.html" aria-label="AO Globe Life home">
+      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+    </a>
+    <nav class="nav-links" aria-label="Main">
+      <a href="history.html">History &amp; Timeline</a>
+      <a href="community.html">Community</a>
+      <a href="company.html">Company</a>
+      <a href="module1.html" aria-current="page">Training</a>
+      <a href="contact.html">Contact</a>
     </nav>
+    <span id="auth" class="auth-status"></span>
   </header>
   <main>
+    <p><strong>Need the Hiring Checklist?</strong> <a href="checklist.html">Review it here.</a></p>
     <details>
       <summary>Module 1 – Basic Support Instructions</summary>
       <p>Module 1 begins your training for the Veteran’s Division. Each chapter includes multiple subsections that support the tasks for that chapter. Chapters 1 through 5 typically take about an hour each, while Chapter 6 usually requires two to four hours. Once your Chapter 6 video is approved, you will move on to Module A to complete the No‑Cost Benefits presentation. You have two days to complete Module 1.</p>


### PR DESCRIPTION
## Summary
- create a shared navigation stylesheet and apply the same History & Timeline-centric menu across the site
- refresh the company page with a richer overview, support resources, and a call to explore the detailed history timeline
- modernize the shared stylesheet so training utilities inherit the updated typography, layout, and callout styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5af85f68c8325b669340f9e0f9fc7