### PR TITLE
Create glass sidebar navigation

### DIFF
--- a/public/checklist.html
+++ b/public/checklist.html
@@ -10,21 +10,24 @@
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="css/nav.css" />
 </head>
-<body>
-  <header class="site-header">
-    <a class="site-logo" href="index.html" aria-label="AO Globe Life home">
-      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
-    </a>
-    <nav class="nav-links" aria-label="Main">
-      <a href="history.html">History &amp; Timeline</a>
-      <a href="community.html">Community</a>
-      <a href="company.html">Company</a>
-      <a href="module1.html">Training</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-    <span id="auth" class="auth-status"></span>
-  </header>
+<body class="with-glass-menu">
+  <aside class="glass-menu" aria-label="Primary navigation">
+    <div class="glass-menu__inner">
+      <a class="glass-menu__brand" href="index.html" aria-label="AO Globe Life home">
+        <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+      </a>
+      <nav class="glass-menu__nav" aria-label="Main">
+        <a href="history.html">History &amp; Timeline</a>
+        <a href="community.html">Community</a>
+        <a href="company.html">Company</a>
+        <a href="module1.html">Training</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </aside>
+  <div class="page-content">
   <main>
+    <span id="auth" class="auth-status"></span>
     <h1>Hiring Process Checklist</h1>
     <p>Use this checklist to track progress through recruiting and onboarding.</p>
     <h2>1. Recruiting</h2>
@@ -50,6 +53,7 @@
       <li><label><input type="checkbox" /> Final evaluation</label></li>
     </ul>
   </main>
+  </div>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script src="js/config.js"></script>
   <script src="js/auth.js"></script>

--- a/public/community.html
+++ b/public/community.html
@@ -27,28 +27,18 @@
       color: var(--ink);
       background: linear-gradient(180deg, #f7f9fc 0%, #f0f6ff 45%, #f7f9fc 100%);
       min-height: 100vh;
+    }
+
+    .page-content {
+      min-height: 100vh;
       display: flex;
       flex-direction: column;
-    }
-
-    .site-header {
-      width: min(1100px, 92vw);
-      margin: clamp(16px, 5vw, 32px) auto 0;
-      padding: 24px clamp(16px, 6vw, 72px) 16px;
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      justify-content: center;
-      gap: 18px;
-    }
-
-    .site-header .nav-links {
-      justify-content: center;
+      padding: clamp(32px, 6vw, 56px) clamp(24px, 6vw, 48px) clamp(40px, 6vw, 64px);
     }
 
     main {
       width: min(960px, 92vw);
-      margin: 0 auto 64px;
+      margin: 0 auto 48px;
       padding-bottom: 40px;
     }
 
@@ -126,19 +116,22 @@
     }
   </style>
 </head>
-<body>
-  <header class="site-header">
-    <a class="site-logo" href="index.html" aria-label="AO Globe Life home">
-      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
-    </a>
-    <nav class="nav-links" aria-label="Main">
-      <a href="history.html">History &amp; Timeline</a>
-      <a href="community.html" aria-current="page">Community</a>
-      <a href="company.html">Company</a>
-      <a href="module1.html">Training</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </header>
+<body class="with-glass-menu">
+  <aside class="glass-menu" aria-label="Primary navigation">
+    <div class="glass-menu__inner">
+      <a class="glass-menu__brand" href="index.html" aria-label="AO Globe Life home">
+        <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+      </a>
+      <nav class="glass-menu__nav" aria-label="Main">
+        <a href="history.html">History &amp; Timeline</a>
+        <a href="community.html" aria-current="page">Community</a>
+        <a href="company.html">Company</a>
+        <a href="module1.html">Training</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </aside>
+  <div class="page-content">
   <main>
     <h1>Community Outreach &amp; Impact</h1>
     <p class="intro">Beyond our historic milestones, AO Globe Life invests time, talent, and resources into programs that strengthen working families and the communities we serve.</p>
@@ -204,6 +197,7 @@
   <footer>
     &copy; <span id="year"></span> AO Globe Life. All rights reserved.
   </footer>
+  </div>
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>

--- a/public/company.html
+++ b/public/company.html
@@ -10,21 +10,24 @@
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="css/nav.css" />
 </head>
-<body>
-  <header class="site-header">
-    <a class="site-logo" href="index.html" aria-label="AO Globe Life home">
-      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
-    </a>
-    <nav class="nav-links" aria-label="Main">
-      <a href="history.html">History &amp; Timeline</a>
-      <a href="community.html">Community</a>
-      <a href="company.html" aria-current="page">Company</a>
-      <a href="module1.html">Training</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-    <span id="auth" class="auth-status"></span>
-  </header>
+<body class="with-glass-menu">
+  <aside class="glass-menu" aria-label="Primary navigation">
+    <div class="glass-menu__inner">
+      <a class="glass-menu__brand" href="index.html" aria-label="AO Globe Life home">
+        <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+      </a>
+      <nav class="glass-menu__nav" aria-label="Main">
+        <a href="history.html">History &amp; Timeline</a>
+        <a href="community.html">Community</a>
+        <a href="company.html" aria-current="page">Company</a>
+        <a href="module1.html">Training</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </aside>
+  <div class="page-content">
   <main>
+    <span id="auth" class="auth-status"></span>
     <div class="page-hero">
       <h1>AO Globe Life Company Overview</h1>
       <p class="intro">From our labor roots to today's national reach, AO Globe Life connects the strength of Globe Life with a
@@ -85,6 +88,7 @@
       <a href="history.html">View the History &amp; Timeline</a>
     </section>
   </main>
+  </div>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script src="js/config.js"></script>
   <script src="js/auth.js"></script>

--- a/public/contact.html
+++ b/public/contact.html
@@ -27,28 +27,18 @@
       color: var(--ink);
       background: linear-gradient(180deg, #f7f9fc 0%, #f0f6ff 45%, #f7f9fc 100%);
       min-height: 100vh;
+    }
+
+    .page-content {
+      min-height: 100vh;
       display: flex;
       flex-direction: column;
-    }
-
-    .site-header {
-      width: min(1100px, 92vw);
-      margin: clamp(16px, 5vw, 32px) auto 0;
-      padding: 24px clamp(16px, 6vw, 72px) 16px;
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      justify-content: center;
-      gap: 18px;
-    }
-
-    .site-header .nav-links {
-      justify-content: center;
+      padding: clamp(32px, 6vw, 56px) clamp(24px, 6vw, 48px) clamp(40px, 6vw, 64px);
     }
 
     main {
       width: min(900px, 92vw);
-      margin: 0 auto 64px;
+      margin: 0 auto 48px;
       padding-bottom: 40px;
     }
 
@@ -115,19 +105,22 @@
     }
   </style>
 </head>
-<body>
-  <header class="site-header">
-    <a class="site-logo" href="index.html" aria-label="AO Globe Life home">
-      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
-    </a>
-    <nav class="nav-links" aria-label="Main">
-      <a href="history.html">History &amp; Timeline</a>
-      <a href="community.html">Community</a>
-      <a href="company.html">Company</a>
-      <a href="module1.html">Training</a>
-      <a href="contact.html" aria-current="page">Contact</a>
-    </nav>
-  </header>
+<body class="with-glass-menu">
+  <aside class="glass-menu" aria-label="Primary navigation">
+    <div class="glass-menu__inner">
+      <a class="glass-menu__brand" href="index.html" aria-label="AO Globe Life home">
+        <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+      </a>
+      <nav class="glass-menu__nav" aria-label="Main">
+        <a href="history.html">History &amp; Timeline</a>
+        <a href="community.html">Community</a>
+        <a href="company.html">Company</a>
+        <a href="module1.html">Training</a>
+        <a href="contact.html" aria-current="page">Contact</a>
+      </nav>
+    </div>
+  </aside>
+  <div class="page-content">
   <main>
     <h1>Contact</h1>
     <p class="intro">Reach the right AO Globe Life or Globe Life team below. We look forward to connecting with you.</p>
@@ -164,6 +157,7 @@
   <footer>
     &copy; <span id="year"></span> AO Globe Life. All rights reserved.
   </footer>
+  </div>
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>

--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -3,75 +3,212 @@
   --ao-green: #00a870;
   --ink: #1f2937;
   --muted: #6b7280;
+  --menu-width: clamp(220px, 24vw, 260px);
+  --menu-surface: rgba(255, 255, 255, 0.86);
+  --menu-highlight: rgba(255, 255, 255, 0.95);
+  --menu-border: rgba(255, 255, 255, 0.65);
+  --menu-shadow: 24px 0 48px -28px rgba(20, 36, 64, 0.28);
+  --menu-rib-sheen: linear-gradient(90deg, rgba(212, 216, 222, 0.95), rgba(247, 248, 250, 0.95) 45%, rgba(186, 191, 198, 0.94));
 }
 
-.site-header {
-  width: min(1080px, 92vw);
-  margin: clamp(16px, 5vw, 32px) auto 0;
-  padding: 24px clamp(16px, 6vw, 72px) 16px;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: clamp(12px, 4vw, 24px);
-}
-
-.site-logo {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.site-logo img {
-  height: clamp(40px, 6vw, 56px);
-  width: auto;
-  filter: drop-shadow(0 8px 20px rgba(10, 62, 122, 0.14));
-}
-
-.nav-links {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 14px;
-  padding: 0;
+body.with-glass-menu {
   margin: 0;
-  list-style: none;
+  min-height: 100vh;
 }
 
-.nav-links a {
+.with-glass-menu .page-content {
+  margin-left: var(--menu-width);
+  min-height: 100vh;
+}
+
+.glass-menu {
+  position: fixed;
+  inset: 0 auto 0 0;
+  width: var(--menu-width);
+  padding: clamp(28px, 5vw, 42px) clamp(18px, 4vw, 28px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 6vh, 40px);
+  background: linear-gradient(165deg, rgba(255, 255, 255, 0.96), rgba(236, 242, 252, 0.8));
+  border-right: 1px solid var(--menu-border);
+  box-shadow: var(--menu-shadow);
+  backdrop-filter: blur(26px);
+  -webkit-backdrop-filter: blur(26px);
+  z-index: 100;
+}
+
+.glass-menu::before {
+  content: '';
+  position: absolute;
+  inset: clamp(18px, 4vw, 26px);
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  pointer-events: none;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.35), rgba(211, 224, 238, 0.08));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), inset 0 -18px 28px rgba(115, 138, 164, 0.14);
+}
+
+.glass-menu__inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: clamp(24px, 5vh, 36px);
+  height: 100%;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.glass-menu__brand {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px;
+  border-radius: 20px;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.78), rgba(232, 238, 246, 0.54));
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9), inset 0 -10px 18px rgba(120, 146, 170, 0.16), 0 18px 38px rgba(20, 52, 92, 0.18);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.glass-menu__brand:focus-visible {
+  outline: 2px solid rgba(14, 165, 233, 0.65);
+  outline-offset: 4px;
+}
+
+.glass-menu__brand:hover {
+  transform: translateY(-3px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.95), inset 0 -14px 24px rgba(110, 138, 170, 0.2), 0 24px 48px rgba(16, 46, 88, 0.22);
+}
+
+.glass-menu__brand img {
+  display: block;
+  width: 100%;
+  height: auto;
+  filter: drop-shadow(0 8px 20px rgba(10, 62, 122, 0.25));
+}
+
+.glass-menu__nav {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(26px, 5vh, 38px);
+  margin: 0;
+  padding: 0;
+}
+
+.glass-menu__nav a {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+  width: 100%;
+  padding: 14px 18px;
+  border-radius: 18px;
+  color: rgba(15, 38, 72, 0.88);
   text-decoration: none;
   font-weight: 600;
   letter-spacing: 0.2px;
-  color: #fff;
-  background: linear-gradient(120deg, var(--ao-blue), var(--ao-green));
-  padding: 12px 22px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.82), rgba(230, 237, 245, 0.6));
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9), inset 0 -12px 26px rgba(110, 134, 162, 0.18), 0 16px 32px rgba(18, 46, 88, 0.18);
+  transition: transform 0.35s ease, box-shadow 0.35s ease, background 0.35s ease, color 0.35s ease;
+}
+
+.glass-menu__nav a::before {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 14px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0));
+  opacity: 0.65;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.glass-menu__nav a::after {
+  content: '';
+  position: absolute;
+  left: 14%;
+  right: 14%;
+  bottom: -16px;
+  height: 8px;
   border-radius: 999px;
-  box-shadow: 0 12px 26px rgba(10, 62, 122, 0.18);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  background: var(--menu-rib-sheen);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.75), inset 0 -2px 2px rgba(116, 120, 126, 0.28), 0 1px 2px rgba(255, 255, 255, 0.45);
 }
 
-.nav-links a:hover,
-.nav-links a:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 28px rgba(10, 62, 122, 0.22);
+.glass-menu__nav a:last-child::after {
+  display: none;
 }
 
-.nav-links a:focus-visible {
-  outline: 2px solid #fff;
-  outline-offset: 3px;
+.glass-menu__nav a:hover,
+.glass-menu__nav a:focus-visible,
+.glass-menu__nav a[aria-current="page"] {
+  color: var(--ao-blue);
+  transform: translateX(8px);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.98), rgba(214, 233, 255, 0.68));
+  box-shadow: inset 0 0 22px rgba(30, 134, 255, 0.28), 0 22px 42px rgba(16, 62, 122, 0.26);
+}
+
+.glass-menu__nav a:hover::before,
+.glass-menu__nav a:focus-visible::before,
+.glass-menu__nav a[aria-current="page"]::before {
+  opacity: 0.85;
+}
+
+.glass-menu__nav a:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 24px rgba(30, 134, 255, 0.32), 0 24px 48px rgba(16, 62, 122, 0.28);
+}
+
+.glass-menu__nav a:active {
+  transform: translateX(10px) scale(0.99);
+  box-shadow: inset 0 0 26px rgba(24, 128, 245, 0.45), 0 18px 36px rgba(14, 58, 116, 0.3);
+}
+
+.glass-menu__nav a span {
+  position: relative;
+  z-index: 1;
+}
+
+.glass-menu__inner::-webkit-scrollbar {
+  width: 6px;
+}
+
+.glass-menu__inner::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.glass-menu__inner::-webkit-scrollbar-thumb {
+  background: rgba(160, 175, 190, 0.45);
+  border-radius: 999px;
 }
 
 .auth-status {
+  display: block;
+  margin-bottom: 16px;
+  text-align: right;
   font-weight: 600;
-  color: var(--ink);
-  margin-left: auto;
+  letter-spacing: 0.2px;
+  color: rgba(31, 41, 55, 0.58);
 }
 
-@media (max-width: 640px) {
-  .site-header {
-    justify-content: center;
+@media (max-width: 960px) {
+  :root {
+    --menu-width: clamp(200px, 32vw, 232px);
+  }
+}
+
+@media (max-width: 720px) {
+  :root {
+    --menu-width: clamp(190px, 45vw, 210px);
+  }
+  .with-glass-menu .page-content {
+    margin-left: var(--menu-width);
+  }
+  .glass-menu {
+    padding: 24px 18px;
   }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -15,7 +15,7 @@ body {
 
 main {
   width: min(1080px, 92vw);
-  margin: 0 auto 72px;
+  margin: clamp(24px, 6vw, 48px) auto 72px;
   padding: clamp(24px, 5vw, 36px) clamp(16px, 6vw, 48px);
   background: var(--surface);
   border-radius: 24px;

--- a/public/history.html
+++ b/public/history.html
@@ -29,15 +29,7 @@
     * { box-sizing: border-box; }
     body { font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; margin: 0; background:#f7f9fc; color: var(--ink); }
     header { padding: 28px 16px 0; text-align: center; }
-    .global-nav {
-      width: min(1100px, 92vw);
-      margin: clamp(16px, 5vw, 32px) auto 0;
-      justify-content: center;
-      gap: 18px;
-    }
-    .global-nav .nav-links {
-      justify-content: center;
-    }
+    .history-page .page-content { padding: clamp(24px, 6vw, 48px) 0; }
     h1 { margin: 0 0 6px; color: var(--brand); font-size: 28px; }
     .subtitle { color: var(--muted); font-size: 14px; margin-bottom: 8px; }
 
@@ -180,7 +172,7 @@
   .footer-head h3{margin:0 0 4px;color:var(--brand);font-size:18px}
   .footer-head .small{margin:0;color:var(--muted)}
   body{padding-bottom:68px}
-  .sticky-bar{position:fixed;bottom:0;left:0;right:0;background:#0a3e7a;color:#fff;box-shadow:0 -4px 18px rgba(0,0,0,.12);z-index:100}
+  .sticky-bar{position:fixed;bottom:0;left:var(--menu-width);right:0;background:#0a3e7a;color:#fff;box-shadow:0 -4px 18px rgba(0,0,0,.12);z-index:100}
   .sticky-inner{max-width:1080px;margin:0 auto;padding:10px 16px;display:flex;align-items:center;justify-content:space-between;gap:12px}
   .sticky-left{display:flex;align-items:center;gap:10px;font-weight:700;letter-spacing:.2px}
   .sticky-left span.handle{opacity:.9;font-weight:600}
@@ -294,19 +286,22 @@
   body.theme-light .footer-head h3{ color:var(--ao-blue) }
 </style>
 </head>
-<body>
-  <div class="site-header global-nav">
-    <a class="site-logo" href="index.html" aria-label="AO Globe Life home">
-      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
-    </a>
-    <nav class="nav-links" aria-label="Main">
-      <a href="history.html" aria-current="page">History &amp; Timeline</a>
-      <a href="community.html">Community</a>
-      <a href="company.html">Company</a>
-      <a href="module1.html">Training</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </div>
+<body class="with-glass-menu history-page">
+  <aside class="glass-menu" aria-label="Primary navigation">
+    <div class="glass-menu__inner">
+      <a class="glass-menu__brand" href="index.html" aria-label="AO Globe Life home">
+        <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+      </a>
+      <nav class="glass-menu__nav" aria-label="Main">
+        <a href="history.html" aria-current="page">History &amp; Timeline</a>
+        <a href="community.html">Community</a>
+        <a href="company.html">Company</a>
+        <a href="module1.html">Training</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </aside>
+  <div class="page-content">
   <div class="layout-grid">
     <nav class="primary-menu" aria-label="Section navigation">
       <button class="menu-button" type="button" aria-expanded="false" aria-haspopup="true" aria-controls="primaryMenuList">
@@ -616,6 +611,7 @@
     </article>
   </section>
     </main>
+  </div>
   </div>
 
   <script>

--- a/public/index.html
+++ b/public/index.html
@@ -24,14 +24,18 @@
     body {
       margin: 0;
       min-height: 100vh;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+    }
+
+    .landing-layout {
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
       gap: 56px;
-      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      color: var(--ink);
-      background: var(--bg);
+      padding: clamp(48px, 8vw, 72px);
     }
 
     .logo-wrapper {
@@ -61,13 +65,10 @@
       padding: 0 24px;
     }
 
-    body > nav.nav-links {
-      padding: 0 24px 32px;
-    }
-
     @media (max-width: 540px) {
-      body {
+      .landing-layout {
         gap: 40px;
+        padding: clamp(32px, 10vw, 56px);
       }
 
       .logo-wrapper {
@@ -77,17 +78,26 @@
     }
   </style>
 </head>
-<body>
-  <div class="logo-wrapper" aria-label="AO Globe Life">
-    <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
-  </div>
-  <p class="tagline">Explore the history, community outreach, and opportunities that define AO Globe Life.</p>
-  <nav class="nav-links" aria-label="Main">
-    <a href="history.html">History &amp; Timeline</a>
-    <a href="community.html">Community</a>
-    <a href="company.html">Company</a>
-    <a href="module1.html">Training</a>
-    <a href="contact.html">Contact</a>
-  </nav>
+<body class="with-glass-menu">
+  <aside class="glass-menu" aria-label="Primary navigation">
+    <div class="glass-menu__inner">
+      <a class="glass-menu__brand" href="index.html" aria-label="AO Globe Life home">
+        <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+      </a>
+      <nav class="glass-menu__nav" aria-label="Main">
+        <a href="history.html">History &amp; Timeline</a>
+        <a href="community.html">Community</a>
+        <a href="company.html">Company</a>
+        <a href="module1.html">Training</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </aside>
+  <main class="page-content landing-layout" aria-labelledby="landing-tagline">
+    <div class="logo-wrapper" aria-label="AO Globe Life">
+      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+    </div>
+    <p id="landing-tagline" class="tagline">Explore the history, community outreach, and opportunities that define AO Globe Life.</p>
+  </main>
 </body>
 </html>

--- a/public/module1.html
+++ b/public/module1.html
@@ -10,21 +10,24 @@
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="css/nav.css" />
 </head>
-<body>
-  <header class="site-header">
-    <a class="site-logo" href="index.html" aria-label="AO Globe Life home">
-      <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
-    </a>
-    <nav class="nav-links" aria-label="Main">
-      <a href="history.html">History &amp; Timeline</a>
-      <a href="community.html">Community</a>
-      <a href="company.html">Company</a>
-      <a href="module1.html" aria-current="page">Training</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-    <span id="auth" class="auth-status"></span>
-  </header>
+<body class="with-glass-menu">
+  <aside class="glass-menu" aria-label="Primary navigation">
+    <div class="glass-menu__inner">
+      <a class="glass-menu__brand" href="index.html" aria-label="AO Globe Life home">
+        <img src="Ao%20Globe%20Life%20Full%20Logo.png" alt="AO Globe Life" />
+      </a>
+      <nav class="glass-menu__nav" aria-label="Main">
+        <a href="history.html">History &amp; Timeline</a>
+        <a href="community.html">Community</a>
+        <a href="company.html">Company</a>
+        <a href="module1.html" aria-current="page">Training</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </aside>
+  <div class="page-content">
   <main>
+    <span id="auth" class="auth-status"></span>
     <p><strong>Need the Hiring Checklist?</strong> <a href="checklist.html">Review it here.</a></p>
     <details>
       <summary>Module 1 – Basic Support Instructions</summary>
@@ -129,6 +132,8 @@
         </div>
       </div>
     </div>
+  </div>
+  </main>
   </div>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script src="js/config.js"></script>


### PR DESCRIPTION
## Summary
- add a reusable glass sidebar navigation with metallic ribs and illuminated hover states
- update the landing and content pages to consume the new sidebar layout and spacing
- align existing timeline/sticky components with the sidebar footprint

## Testing
- not run (static assets change)


------
https://chatgpt.com/codex/tasks/task_e_68d6ac7174dc832588a10c0acf137248