### PR TITLE
Standardize glass menu layout

### DIFF
--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -25,10 +25,10 @@ body.with-glass-menu {
   position: fixed;
   inset: 0 auto 0 0;
   width: var(--menu-width);
-  padding: clamp(32px, 6vh, 44px) clamp(18px, 3vw, 26px);
+  padding: 36px 24px;
   display: flex;
   flex-direction: column;
-  gap: clamp(24px, 6vh, 40px);
+  gap: 32px;
   background: linear-gradient(180deg, rgba(8, 52, 104, 0.96), rgba(5, 40, 84, 0.98));
   border-right: 1px solid var(--menu-border);
   box-shadow: var(--menu-shadow);
@@ -80,7 +80,7 @@ body.with-glass-menu {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: clamp(24px, 5vh, 36px);
+  gap: 32px;
   height: 100%;
   overflow-y: auto;
   padding-right: 4px;
@@ -91,7 +91,7 @@ body.with-glass-menu {
   align-items: center;
   justify-content: center;
   padding: 14px;
-  border-radius: 20px;
+  border-radius: 0;
   background: linear-gradient(160deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.05));
   border: 1px solid rgba(255, 255, 255, 0.25);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), inset 0 -10px 18px rgba(10, 30, 58, 0.24), 0 18px 38px rgba(0, 0, 0, 0.18);
@@ -121,23 +121,17 @@ body.with-glass-menu {
   flex-direction: column;
   gap: 0;
   margin: 0;
-  padding: clamp(20px, 4vh, 28px) 0;
-  border-radius: 32px;
-  background: linear-gradient(140deg, #f7f8fa 0%, #e6e9ef 28%, #c9ced7 52%, #f1f3f7 100%);
-  box-shadow: 0 28px 48px rgba(7, 20, 36, 0.46), inset 0 2px 4px rgba(255, 255, 255, 0.7), inset 0 -6px 12px rgba(78, 86, 98, 0.3);
-  border: 2px solid rgba(207, 214, 224, 0.9);
-  overflow: hidden;
-  isolation: isolate;
+  padding: 0;
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+  border: none;
+  overflow: visible;
+  isolation: auto;
 }
 
 .glass-menu__nav::before {
-  content: '';
-  position: absolute;
-  inset: 6px;
-  border-radius: 28px;
-  background: linear-gradient(180deg, rgba(38, 44, 56, 0.95), rgba(22, 26, 34, 0.9));
-  box-shadow: inset 0 10px 24px rgba(255, 255, 255, 0.12), inset 0 -18px 30px rgba(0, 0, 0, 0.55);
-  z-index: 0;
+  content: none;
 }
 
 .glass-menu__nav a {
@@ -148,7 +142,8 @@ body.with-glass-menu {
   justify-content: flex-start;
   gap: 12px;
   width: 100%;
-  padding: clamp(16px, 4vh, 20px) clamp(24px, 6vw, 28px);
+  padding: 18px 28px;
+  border-radius: 0;
   color: #050608;
   text-decoration: none;
   font-weight: 600;
@@ -179,7 +174,7 @@ body.with-glass-menu {
   content: '';
   position: absolute;
   inset: 0;
-  border-radius: 999px 24px 24px 999px;
+  border-radius: 0;
   background: linear-gradient(120deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
   opacity: 0.35;
   mix-blend-mode: screen;
@@ -237,20 +232,8 @@ body.with-glass-menu {
   color: rgba(31, 41, 55, 0.58);
 }
 
-@media (max-width: 960px) {
-  :root {
-    --menu-width: 232px;
-  }
-}
-
 @media (max-width: 720px) {
-  :root {
-    --menu-width: 210px;
-  }
   .with-glass-menu .page-content {
     margin-left: var(--menu-width);
-  }
-  .glass-menu {
-    padding: 24px 18px;
   }
 }


### PR DESCRIPTION
## Summary
- set fixed padding and spacing on the glass menu container so it keeps a consistent footprint across screens
- remove the decorative frame styling around the navigation list so menu buttons span the full menu width and drop rounded corners
- square off the brand frame to match the updated menu frames

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6cc9ce02483259ffd48686cae2a90