### PR TITLE
Refine glass menu styling

### DIFF
--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -4,6 +4,7 @@
   --ink: #1f2937;
   --muted: #6b7280;
   --menu-width: 260px;
+  --menu-padding: 24px;
   --menu-surface: rgba(255, 255, 255, 0.14);
   --menu-highlight: rgba(255, 255, 255, 0.18);
   --menu-border: rgba(255, 255, 255, 0.22);
@@ -14,6 +15,7 @@
 body.with-glass-menu {
   margin: 0;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 .with-glass-menu .page-content {
@@ -25,7 +27,7 @@ body.with-glass-menu {
   position: fixed;
   inset: 0 auto 0 0;
   width: var(--menu-width);
-  padding: 36px 24px;
+  padding: 36px 0;
   display: flex;
   flex-direction: column;
   gap: 32px;
@@ -33,7 +35,7 @@ body.with-glass-menu {
   border-right: 1px solid var(--menu-border);
   box-shadow: var(--menu-shadow);
   z-index: 100;
-  overflow: visible;
+  overflow: hidden;
 }
 
 .glass-menu::before,
@@ -43,13 +45,12 @@ body.with-glass-menu {
   top: 0;
   bottom: 0;
   width: 16px;
-  border-radius: 999px;
   pointer-events: none;
   z-index: 0;
 }
 
 .glass-menu::before {
-  left: -8px;
+  left: 0;
   background: linear-gradient(
       90deg,
       rgba(36, 40, 48, 0.55) 0%,
@@ -62,7 +63,7 @@ body.with-glass-menu {
 }
 
 .glass-menu::after {
-  right: -10px;
+  right: 0;
   background: linear-gradient(
       90deg,
       rgba(24, 28, 36, 0.65) 0%,
@@ -83,13 +84,15 @@ body.with-glass-menu {
   gap: 32px;
   height: 100%;
   overflow-y: auto;
-  padding-right: 4px;
+  overflow-x: hidden;
+  padding: 0;
 }
 
 .glass-menu__brand {
   display: flex;
   align-items: center;
   justify-content: center;
+  margin: 0 var(--menu-padding);
   padding: 14px;
   border-radius: 0;
   background: linear-gradient(160deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.05));
@@ -142,7 +145,7 @@ body.with-glass-menu {
   justify-content: flex-start;
   gap: 12px;
   width: 100%;
-  padding: 18px 28px;
+  padding: 18px calc(var(--menu-padding) + 4px);
   border-radius: 0;
   color: #050608;
   text-decoration: none;
@@ -154,8 +157,7 @@ body.with-glass-menu {
   background-repeat: no-repeat;
   background-blend-mode: screen, normal;
   box-shadow: inset 2px 1px 6px rgba(255, 255, 255, 0.6), inset -6px -4px 12px rgba(34, 34, 34, 0.45), 0 2px 10px rgba(0, 0, 0, 0.32);
-  transform-origin: left center;
-  transition: transform 0.3s ease, box-shadow 0.3s ease, color 0.3s ease, background-position 0.3s ease;
+  transition: background 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
 }
 
 .glass-menu__nav a + a::before {
@@ -181,28 +183,46 @@ body.with-glass-menu {
   pointer-events: none;
 }
 
+
 .glass-menu__nav a:hover,
-.glass-menu__nav a:focus-visible,
+.glass-menu__nav a:focus-visible {
+  color: #032a1b;
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 168, 112, 0.35),
+    inset 0 0 18px rgba(0, 168, 112, 0.45),
+    0 12px 24px rgba(0, 0, 0, 0.34);
+}
+
 .glass-menu__nav a[aria-current="page"] {
-  color: #050608;
-  transform: perspective(600px) rotateY(-6deg);
-  box-shadow: inset 4px 2px 12px rgba(255, 255, 255, 0.68), inset -10px -6px 18px rgba(32, 32, 32, 0.52), 0 16px 28px rgba(0, 0, 0, 0.38);
+  color: #021d13;
+  background:
+    radial-gradient(140% 120% at 0% 50%, rgba(0, 168, 112, 0.32) 0%, rgba(0, 168, 112, 0.16) 42%, rgba(255, 255, 255, 0) 68%),
+    linear-gradient(112deg, rgba(0, 168, 112, 0.32) 0%, rgba(4, 116, 78, 0.24) 48%, rgba(2, 58, 39, 0.32) 100%);
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 168, 112, 0.55),
+    inset 0 0 28px rgba(0, 168, 112, 0.5),
+    0 18px 32px rgba(0, 0, 0, 0.38);
 }
 
 .glass-menu__nav a:hover::after,
-.glass-menu__nav a:focus-visible::after,
-.glass-menu__nav a[aria-current="page"]::after {
+.glass-menu__nav a:focus-visible::after {
   opacity: 0.6;
 }
 
+.glass-menu__nav a[aria-current="page"]::after {
+  opacity: 0.75;
+}
+
 .glass-menu__nav a:focus-visible {
-  outline: 2px solid rgba(172, 186, 206, 0.7);
+  outline: 2px solid rgba(0, 168, 112, 0.5);
   outline-offset: -4px;
 }
 
 .glass-menu__nav a:active {
-  transform: perspective(600px) rotateY(-3deg) scale(0.995);
-  box-shadow: inset 4px 2px 12px rgba(255, 255, 255, 0.56), inset -8px -5px 16px rgba(34, 34, 34, 0.5), 0 8px 16px rgba(0, 0, 0, 0.38);
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 168, 112, 0.5),
+    inset 0 0 20px rgba(0, 168, 112, 0.55),
+    0 10px 20px rgba(0, 0, 0, 0.38);
 }
 
 .glass-menu__nav a span {


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling in the glass menu and square off the vertical frame rails
- extend the navigation buttons the full width between the frame rails for a consistent menu width
- add green glow hover states and a brighter active highlight for the current page

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d6e0c580c48325bd70f6613c7cb098