### PR TITLE
Fix training modal stacking so menu matches other screens

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -108,6 +108,7 @@ summary {
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: 200;
 }
 
 .modal.hidden {

--- a/public/module1.html
+++ b/public/module1.html
@@ -133,7 +133,6 @@
       </div>
     </div>
   </div>
-  </main>
   </div>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script src="js/config.js"></script>


### PR DESCRIPTION
## Summary
- remove an extra closing `<main>` tag on the Module 1 training page so the layout tree matches the rest of the site
- raise the financial analysis modal's z-index to ensure it overlays the fixed glass menu instead of appearing underneath it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daacd8dc708325923a658a217a8c3a