### PR TITLE
Refine glass menu button styling

### DIFF
--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -109,6 +109,7 @@ body.with-glass-menu {
   background-repeat: no-repeat;
   box-shadow: var(--menu-button-shadow);
   border: 1px solid rgba(10, 62, 122, 0.12);
+  border-radius: 20px;
   overflow: hidden;
   transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
 }
@@ -121,8 +122,9 @@ body.with-glass-menu {
 .glass-menu__brand::after {
   content: '';
   position: absolute;
-  inset: 0;
+  inset: 2px;
   background: linear-gradient(120deg, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0));
+  border-radius: inherit;
   opacity: 0.4;
   pointer-events: none;
 }
@@ -133,8 +135,8 @@ body.with-glass-menu {
   border-color: rgba(0, 168, 112, 0.45);
   box-shadow:
     inset 0 0 0 1px rgba(0, 168, 112, 0.92),
-    inset 0 0 0 3px rgba(0, 168, 112, 0.35),
-    inset 0 0 0 6px rgba(0, 168, 112, 0.12),
+    inset 0 0 0 6px rgba(0, 168, 112, 0.35),
+    inset 0 0 0 12px rgba(0, 168, 112, 0.12),
     inset 1px 1px 6px rgba(255, 255, 255, 0.75),
     inset -6px -4px 12px rgba(34, 34, 34, 0.32),
     0 18px 32px rgba(0, 0, 0, 0.3);
@@ -150,9 +152,9 @@ body.with-glass-menu {
 }
 
 .glass-menu__brand:active {
-  background: linear-gradient(140deg, rgba(0, 168, 112, 0.46), rgba(0, 168, 112, 0.28)), var(--menu-button-surface);
-  border-color: rgba(0, 168, 112, 0.5);
-  box-shadow: inset 0 0 0 1px rgba(0, 168, 112, 0.5), inset 0 0 20px rgba(0, 168, 112, 0.55), 0 10px 20px rgba(0, 0, 0, 0.38);
+  background: linear-gradient(140deg, #00a870, #02855c), var(--menu-button-surface);
+  border-color: rgba(0, 168, 112, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(0, 168, 112, 0.75), inset 0 0 24px rgba(0, 168, 112, 0.65), 0 10px 20px rgba(0, 0, 0, 0.38);
 }
 
 .glass-menu__brand img {
@@ -199,8 +201,9 @@ body.with-glass-menu {
 .glass-menu__nav a::after {
   content: '';
   position: absolute;
-  inset: 0;
+  inset: 2px;
   background: linear-gradient(120deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
+  border-radius: inherit;
   opacity: 0.24;
   pointer-events: none;
 }
@@ -213,8 +216,8 @@ body.with-glass-menu {
   border-color: rgba(0, 168, 112, 0.45);
   box-shadow:
     inset 0 0 0 1px rgba(0, 168, 112, 0.95),
-    inset 0 0 0 3px rgba(0, 168, 112, 0.38),
-    inset 0 0 0 6px rgba(0, 168, 112, 0.14),
+    inset 0 0 0 6px rgba(0, 168, 112, 0.38),
+    inset 0 0 0 12px rgba(0, 168, 112, 0.14),
     inset 1px 1px 6px rgba(255, 255, 255, 0.75),
     inset -6px -4px 12px rgba(34, 34, 34, 0.32),
     0 16px 28px rgba(0, 0, 0, 0.34);
@@ -223,11 +226,11 @@ body.with-glass-menu {
 .glass-menu__nav a[aria-current="page"] {
   color: #021d13;
   font-weight: 700;
-  background: linear-gradient(132deg, rgba(0, 168, 112, 0.4), rgba(0, 168, 112, 0.22)), var(--menu-button-surface);
-  border-color: rgba(0, 168, 112, 0.55);
+  background: linear-gradient(132deg, #00a870, #029663), var(--menu-button-surface);
+  border-color: rgba(0, 168, 112, 0.65);
   box-shadow:
-    inset 0 0 0 1px rgba(0, 168, 112, 0.55),
-    inset 0 0 28px rgba(0, 168, 112, 0.5),
+    inset 0 0 0 1px rgba(0, 168, 112, 0.75),
+    inset 0 0 32px rgba(0, 168, 112, 0.65),
     0 18px 32px rgba(0, 0, 0, 0.38);
 }
 
@@ -246,11 +249,11 @@ body.with-glass-menu {
 }
 
 .glass-menu__nav a:active {
-  background: linear-gradient(140deg, rgba(0, 168, 112, 0.46), rgba(0, 168, 112, 0.28)), var(--menu-button-surface);
-  border-color: rgba(0, 168, 112, 0.5);
+  background: linear-gradient(140deg, #00a870, #02855c), var(--menu-button-surface);
+  border-color: rgba(0, 168, 112, 0.65);
   box-shadow:
-    inset 0 0 0 1px rgba(0, 168, 112, 0.5),
-    inset 0 0 20px rgba(0, 168, 112, 0.55),
+    inset 0 0 0 1px rgba(0, 168, 112, 0.75),
+    inset 0 0 24px rgba(0, 168, 112, 0.65),
     0 10px 20px rgba(0, 0, 0, 0.38);
 }
 


### PR DESCRIPTION
## Summary
- prevent glass menu buttons from bleeding over the frame by adding internal rounding to their overlays
- deepen hover glow distance and make the active/selected green styles fully opaque for consistency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dad07d0bac8325914046819c581620