### PR TITLE
Ensure navigation buttons sit beneath frame

### DIFF
--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -56,7 +56,7 @@ body.with-glass-menu {
   bottom: 0;
   width: 16px;
   pointer-events: none;
-  z-index: 0;
+  z-index: 2;
 }
 
 .glass-menu::before {
@@ -104,6 +104,7 @@ body.with-glass-menu {
   display: flex;
   align-items: center;
   width: 100%;
+  box-sizing: border-box;
   padding: var(--menu-button-padding-y) var(--menu-button-padding-x);
   background: var(--menu-button-surface);
   background-repeat: no-repeat;


### PR DESCRIPTION
## Summary
- increase the z-index of the menu frame ribs so the navigation buttons sit beneath the metallic frame treatment
- force the navigation brand link and buttons to use border-box sizing so their borders stay within the inner frame edge and keep square corners

## Testing
- Not Run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc454810748325a7b8523900ee52ba