### PR TITLE
Fix inconsistent glass menu width

### DIFF
--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -51,6 +51,7 @@ body.with-glass-menu {
   inset: 0 auto 0 0;
   width: var(--menu-width);
   padding: 36px 12px;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: 32px;


### PR DESCRIPTION
## Summary
- ensure the glass navigation menu uses border-box sizing so its width matches the defined variable
- align the left navigation width across company, training, and other pages

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dd96c898948325825cdf2928f10e7a