### PR TITLE
Soften glass menu border gradients

### DIFF
--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -58,10 +58,7 @@ body.with-glass-menu {
   flex-direction: column;
   align-items: stretch;
   gap: 28px;
-  background:
-    radial-gradient(120% 110% at 14% 16%, rgba(118, 172, 236, 0.38), rgba(118, 172, 236, 0) 58%),
-    radial-gradient(140% 140% at 92% 84%, rgba(6, 30, 72, 0.55), rgba(6, 30, 72, 0) 62%),
-    linear-gradient(180deg, #0b4486 0%, #073066 48%, #02163c 100%);
+  background: linear-gradient(180deg, #0c3f7d 0%, #09366c 44%, #072d5b 100%);
   border-right: 1px solid rgba(255, 255, 255, 0.18);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 18px 0 42px -26px rgba(6, 18, 44, 0.72);
   z-index: 100;
@@ -73,9 +70,12 @@ body.with-glass-menu {
 .glass-menu::before {
   content: '';
   position: absolute;
-  inset: 36px 12px;
-  border-radius: 26px;
-  background: linear-gradient(180deg, rgba(9, 58, 120, 0.92) 0%, rgba(5, 34, 84, 0.95) 100%);
+  top: 0;
+  bottom: 0;
+  left: 12px;
+  right: 12px;
+  border-radius: 0;
+  background: linear-gradient(180deg, rgba(10, 52, 110, 0.94) 0%, rgba(6, 38, 90, 0.96) 100%);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
   pointer-events: none;
   z-index: 0;
@@ -88,13 +88,13 @@ body.with-glass-menu {
   bottom: 0;
   right: -14px;
   width: 34px;
-  border-radius: 0 22px 22px 0;
+  border-radius: 0;
   background: linear-gradient(
     180deg,
-    rgba(255, 255, 255, 0.45) 0%,
-    rgba(160, 206, 255, 0.16) 45%,
-    rgba(18, 54, 116, 0.24) 74%,
-    rgba(3, 12, 36, 0.58) 100%
+    rgba(255, 255, 255, 0.28) 0%,
+    rgba(160, 206, 255, 0.14) 40%,
+    rgba(36, 72, 126, 0.22) 74%,
+    rgba(8, 18, 40, 0.48) 100%
   );
   box-shadow: 18px 0 32px -20px rgba(3, 7, 18, 0.7);
   pointer-events: none;


### PR DESCRIPTION
## Summary
- replace the glass menu panel background with a single subtle vertical gradient for a smoother contour
- square off the menu backdrop layers and ease their highlights to avoid harsh border shifts

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dda74f5df0832583584095649ce47d