### PR TITLE
Refine active nav button styling

### DIFF
--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -355,9 +355,11 @@ body.theme-dark .glass-menu__social-icon {
 .glass-menu__social a[aria-current="page"] {
   color: #052417;
   font-weight: 700;
-  background: linear-gradient(162deg, rgba(0, 210, 150, 0.95) 0%, rgba(0, 168, 112, 0.95) 52%, rgba(0, 136, 92, 0.95) 100%);
-  border-color: rgba(0, 168, 112, 0.55);
-  box-shadow: 0 20px 34px rgba(0, 64, 44, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.72), inset 0 -10px 18px rgba(0, 78, 54, 0.45);
+  background:
+    radial-gradient(circle at center, rgba(0, 220, 158, 0.32) 0%, rgba(0, 176, 120, 0.12) 42%, rgba(0, 122, 86, 0) 70%),
+    linear-gradient(164deg, rgba(0, 110, 78, 0.98) 0%, rgba(0, 136, 96, 0.98) 50%, rgba(0, 112, 82, 0.98) 100%);
+  border-color: rgba(0, 128, 90, 0.65);
+  box-shadow: 0 22px 36px rgba(0, 48, 32, 0.5), inset 0 2px 4px rgba(255, 255, 255, 0.72), inset 0 -12px 22px rgba(0, 70, 48, 0.55);
 }
 
 .glass-menu__nav a:hover::after,
@@ -374,7 +376,10 @@ body.theme-dark .glass-menu__social-icon {
 
 .glass-menu__nav a[aria-current="page"]::after,
 .glass-menu__social a[aria-current="page"]::after {
-  opacity: 0.75;
+  background:
+    radial-gradient(circle at center, rgba(255, 255, 255, 0.52) 0%, rgba(255, 255, 255, 0.18) 38%, rgba(255, 255, 255, 0) 70%),
+    radial-gradient(circle at 50% 110%, rgba(0, 140, 100, 0.35), rgba(0, 140, 100, 0));
+  opacity: 0.72;
 }
 
 .glass-menu__nav a:focus-visible,
@@ -390,6 +395,17 @@ body.theme-dark .glass-menu__social-icon {
   border-color: rgba(255, 255, 255, 0.42);
   box-shadow: inset 0 8px 14px rgba(6, 26, 58, 0.6), inset 0 -2px 4px rgba(255, 255, 255, 0.3), 0 6px 10px rgba(4, 18, 44, 0.45);
   transform: translateY(3px);
+}
+
+.glass-menu__nav a[aria-current="page"]:active,
+.glass-menu__social a[aria-current="page"]:active {
+  color: #041f15;
+  background:
+    radial-gradient(circle at center, rgba(0, 216, 152, 0.36) 0%, rgba(0, 170, 120, 0.14) 40%, rgba(0, 110, 78, 0) 68%),
+    linear-gradient(168deg, rgba(0, 102, 72, 0.98) 0%, rgba(0, 128, 88, 0.98) 52%, rgba(0, 106, 76, 0.98) 100%);
+  border-color: rgba(0, 120, 84, 0.7);
+  box-shadow: inset 0 10px 16px rgba(0, 64, 44, 0.62), inset 0 -4px 6px rgba(255, 255, 255, 0.28), 0 16px 24px rgba(0, 44, 30, 0.45);
+  transform: translateY(2px);
 }
 
 .glass-menu__nav a > *,


### PR DESCRIPTION
## Summary
- deepen the active navigation button green tones and add a center-focused glow effect
- replace the blue-tinted overlay on selected buttons with a green-highlighted treatment
- ensure active presses keep the richer green styling for aria-current links

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ddb98acb84832596d6b812e257f827