### PR TITLE
Improve dark theme color consistency

### DIFF
--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -110,17 +110,31 @@ body.with-glass-menu {
   flex: 1;
 }
 
-body.theme-dark .glass-menu__section-title {
+body.theme-dark .glass-menu__section-title,
+body:not(.theme-light) .glass-menu__section-title {
   color: rgba(226, 232, 240, 0.6);
 }
 
-body.theme-dark .glass-menu__section {
+body.theme-dark .glass-menu__section,
+body:not(.theme-light) .glass-menu__section {
   border-top-color: rgba(148, 163, 184, 0.35);
 }
 
-body.theme-dark .glass-menu__social-icon {
+body.theme-dark .glass-menu__social-icon,
+body:not(.theme-light) .glass-menu__social-icon {
   background: rgba(148, 163, 184, 0.22);
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.4), 0 6px 12px rgba(2, 6, 23, 0.45);
+}
+
+body.theme-dark .glass-menu__brand,
+body.theme-dark .glass-menu__nav a,
+body.theme-dark .glass-menu__social a,
+body:not(.theme-light) .glass-menu__brand,
+body:not(.theme-light) .glass-menu__nav a,
+body:not(.theme-light) .glass-menu__social a {
+  color: rgba(226, 232, 240, 0.94);
+  border-color: rgba(148, 163, 184, 0.32);
+  text-shadow: 0 1px 0 rgba(2, 6, 23, 0.65);
 }
 
 .glass-menu__brand,
@@ -294,6 +308,23 @@ body.theme-dark .glass-menu__social-icon {
 }
 
 
+body.theme-dark .glass-menu__brand:hover,
+body.theme-dark .glass-menu__brand:focus-visible,
+body.theme-dark .glass-menu__nav a:hover,
+body.theme-dark .glass-menu__nav a:focus-visible,
+body.theme-dark .glass-menu__social a:hover,
+body.theme-dark .glass-menu__social a:focus-visible,
+body:not(.theme-light) .glass-menu__brand:hover,
+body:not(.theme-light) .glass-menu__brand:focus-visible,
+body:not(.theme-light) .glass-menu__nav a:hover,
+body:not(.theme-light) .glass-menu__nav a:focus-visible,
+body:not(.theme-light) .glass-menu__social a:hover,
+body:not(.theme-light) .glass-menu__social a:focus-visible {
+  color: rgba(248, 250, 252, 0.98);
+  border-color: rgba(148, 163, 184, 0.45);
+  text-shadow: 0 1px 0 rgba(2, 6, 23, 0.7);
+}
+
 .glass-menu__nav a:hover,
 .glass-menu__nav a:focus-visible,
 .glass-menu__social a:hover,
@@ -312,6 +343,19 @@ body.theme-dark .glass-menu__social-icon {
 .glass-menu__social a:hover::before,
 .glass-menu__social a:focus-visible::before {
   opacity: 0.9;
+}
+
+body.theme-dark .glass-menu__nav a[aria-current="page"],
+body.theme-dark .glass-menu__social a[aria-current="page"],
+body:not(.theme-light) .glass-menu__nav a[aria-current="page"],
+body:not(.theme-light) .glass-menu__social a[aria-current="page"] {
+  color: #ecfdf5;
+  background:
+    radial-gradient(circle at center, rgba(4, 120, 87, 0.42) 0%, rgba(4, 120, 87, 0.22) 44%, rgba(2, 78, 64, 0) 72%),
+    linear-gradient(164deg, rgba(6, 78, 59, 0.98) 0%, rgba(4, 120, 87, 0.98) 52%, rgba(6, 95, 70, 0.98) 100%);
+  border-color: rgba(16, 185, 129, 0.68);
+  box-shadow: 0 26px 42px rgba(2, 32, 24, 0.55), inset 0 2px 4px rgba(236, 253, 245, 0.72), inset 0 -14px 24px rgba(3, 54, 42, 0.6);
+  text-shadow: 0 1px 0 rgba(2, 6, 23, 0.75);
 }
 
 .glass-menu__nav a[aria-current="page"],
@@ -337,6 +381,16 @@ body.theme-dark .glass-menu__social-icon {
   opacity: 0.7;
 }
 
+body.theme-dark .glass-menu__nav a[aria-current="page"]::after,
+body.theme-dark .glass-menu__social a[aria-current="page"]::after,
+body:not(.theme-light) .glass-menu__nav a[aria-current="page"]::after,
+body:not(.theme-light) .glass-menu__social a[aria-current="page"]::after {
+  background:
+    radial-gradient(circle at center, rgba(241, 245, 249, 0.48) 0%, rgba(241, 245, 249, 0.22) 36%, rgba(241, 245, 249, 0) 68%),
+    radial-gradient(circle at 50% 110%, rgba(16, 185, 129, 0.42), rgba(16, 185, 129, 0));
+  opacity: 0.75;
+}
+
 .glass-menu__nav a[aria-current="page"]::after,
 .glass-menu__social a[aria-current="page"]::after {
   background:
@@ -351,6 +405,17 @@ body.theme-dark .glass-menu__social-icon {
   outline-offset: 4px;
 }
 
+body.theme-dark .glass-menu__brand:active,
+body.theme-dark .glass-menu__nav a:active,
+body.theme-dark .glass-menu__social a:active,
+body:not(.theme-light) .glass-menu__brand:active,
+body:not(.theme-light) .glass-menu__nav a:active,
+body:not(.theme-light) .glass-menu__social a:active {
+  color: rgba(226, 232, 240, 0.96);
+  border-color: rgba(148, 163, 184, 0.5);
+  text-shadow: 0 1px 0 rgba(2, 6, 23, 0.75);
+}
+
 .glass-menu__nav a:active,
 .glass-menu__social a:active {
   color: #02152b;
@@ -358,6 +423,18 @@ body.theme-dark .glass-menu__social-icon {
   border-color: rgba(255, 255, 255, 0.42);
   box-shadow: inset 0 8px 14px rgba(6, 26, 58, 0.6), inset 0 -2px 4px rgba(255, 255, 255, 0.3), 0 6px 10px rgba(4, 18, 44, 0.45);
   transform: translateY(3px);
+}
+
+body.theme-dark .glass-menu__nav a[aria-current="page"]:active,
+body.theme-dark .glass-menu__social a[aria-current="page"]:active,
+body:not(.theme-light) .glass-menu__nav a[aria-current="page"]:active,
+body:not(.theme-light) .glass-menu__social a[aria-current="page"]:active {
+  color: #f0fdf4;
+  background:
+    radial-gradient(circle at center, rgba(5, 150, 105, 0.48) 0%, rgba(5, 150, 105, 0.28) 38%, rgba(6, 78, 59, 0) 66%),
+    linear-gradient(168deg, rgba(6, 68, 54, 0.98) 0%, rgba(5, 122, 85, 0.98) 52%, rgba(4, 94, 75, 0.98) 100%);
+  border-color: rgba(21, 128, 88, 0.72);
+  box-shadow: inset 0 12px 18px rgba(3, 48, 36, 0.68), inset 0 -4px 6px rgba(236, 253, 245, 0.32), 0 18px 26px rgba(2, 32, 24, 0.52);
 }
 
 .glass-menu__nav a[aria-current="page"]:active,
@@ -553,14 +630,16 @@ body.theme-dark .glass-menu__social-icon {
   border: 0;
 }
 
-body.theme-dark .settings-widget__panel {
+body.theme-dark .settings-widget__panel,
+body:not(.theme-light) .settings-widget__panel {
   background: rgba(17, 25, 40, 0.94);
   color: rgba(226, 232, 240, 0.92);
   border-color: rgba(148, 163, 184, 0.18);
   box-shadow: 0 28px 52px rgba(2, 6, 23, 0.65);
 }
 
-body.theme-dark .settings-widget__toggle {
+body.theme-dark .settings-widget__toggle,
+body:not(.theme-light) .settings-widget__toggle {
   background: linear-gradient(135deg, rgba(30, 41, 59, 0.96), rgba(15, 23, 42, 0.96));
   color: rgba(226, 232, 240, 0.92);
   border-color: rgba(148, 163, 184, 0.32);
@@ -568,17 +647,21 @@ body.theme-dark .settings-widget__toggle {
 }
 
 body.theme-dark .settings-widget__label,
-body.theme-dark .settings-widget__legend {
+body.theme-dark .settings-widget__legend,
+body:not(.theme-light) .settings-widget__label,
+body:not(.theme-light) .settings-widget__legend {
   color: rgba(203, 213, 225, 0.75);
 }
 
-body.theme-dark .settings-widget__select {
+body.theme-dark .settings-widget__select,
+body:not(.theme-light) .settings-widget__select {
   background: rgba(30, 41, 59, 0.92);
   color: rgba(226, 232, 240, 0.96);
   border-color: rgba(148, 163, 184, 0.28);
 }
 
-body.theme-dark .settings-widget__radio-group label {
+body.theme-dark .settings-widget__radio-group label,
+body:not(.theme-light) .settings-widget__radio-group label {
   background: rgba(30, 41, 59, 0.92);
   color: rgba(226, 232, 240, 0.92);
   border-color: rgba(148, 163, 184, 0.28);


### PR DESCRIPTION
## Summary
- align manual and automatic dark mode styles for menu, social icons, and settings widget
- improve dark theme button legibility and update selected states with a deeper emerald palette

## Testing
- No tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68deb72857bc8325a7adf65312df11ff