### PR TITLE
Ensure menu buttons appear above frame effects

### DIFF
--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -137,6 +137,7 @@ body:not(.theme-light) .glass-menu__social a {
 .glass-menu__nav a,
 .glass-menu__social a {
   position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -265,7 +266,6 @@ body:not(.theme-light) .glass-menu__social a + a {
 
 .glass-menu__nav a,
 .glass-menu__social a {
-  z-index: 1;
   background-position: center;
 }
 


### PR DESCRIPTION
## Summary
- elevate the stacking context of glass menu buttons so they render above decorative frame effects

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee79bf9ec83259bfb9b98dcf64b04