### PR TITLE
Restyle active navigation buttons to pale silver blue

### DIFF
--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -296,18 +296,18 @@ body:not(.theme-light) .glass-menu__nav a:hover,
 body:not(.theme-light) .glass-menu__nav a:focus-visible,
 body:not(.theme-light) .glass-menu__social a:hover,
 body:not(.theme-light) .glass-menu__social a:focus-visible {
-  color: rgba(248, 250, 252, 0.98);
+  color: #102a4a;
   border-color: rgba(148, 163, 184, 0.45);
-  text-shadow: 0 1px 0 rgba(2, 6, 23, 0.7);
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
 .glass-menu__nav a:hover,
 .glass-menu__nav a:focus-visible,
 .glass-menu__social a:hover,
 .glass-menu__social a:focus-visible {
-  color: #f8fbff;
+  color: #102a4a;
   background: var(--menu-button-surface-pressed);
-  border-color: rgba(255, 255, 255, 0.3);
+  border-color: rgba(255, 255, 255, 0.58);
   box-shadow: var(--menu-button-shadow-pressed);
   transform: none;
 }
@@ -323,20 +323,20 @@ body.theme-dark .glass-menu__nav a[aria-current="page"],
 body.theme-dark .glass-menu__social a[aria-current="page"],
 body:not(.theme-light) .glass-menu__nav a[aria-current="page"],
 body:not(.theme-light) .glass-menu__social a[aria-current="page"] {
-  color: rgba(226, 232, 240, 0.98);
-  background: linear-gradient(180deg, rgba(30, 78, 134, 0.98), rgba(16, 46, 94, 0.98));
-  border-color: rgba(148, 163, 184, 0.45);
-  box-shadow: inset 0 1px 0 rgba(226, 232, 240, 0.2), inset 0 -3px 6px rgba(5, 18, 42, 0.65);
-  text-shadow: 0 1px 0 rgba(2, 6, 23, 0.7);
+  color: #102a4a;
+  background: linear-gradient(180deg, rgba(214, 224, 238, 0.9), rgba(176, 194, 216, 0.88));
+  border-color: rgba(226, 232, 240, 0.6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), inset 0 -3px 6px rgba(118, 144, 178, 0.45);
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
 .glass-menu__nav a[aria-current="page"],
 .glass-menu__social a[aria-current="page"] {
-  color: #f8fbff;
+  color: #102a4a;
   font-weight: 700;
-  background: linear-gradient(180deg, rgba(42, 102, 176, 0.98), rgba(22, 66, 134, 0.98));
-  border-color: rgba(255, 255, 255, 0.32);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.26), inset 0 -3px 6px rgba(14, 46, 98, 0.58);
+  background: linear-gradient(180deg, rgba(226, 236, 248, 0.95), rgba(194, 210, 232, 0.92));
+  border-color: rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45), inset 0 -3px 6px rgba(134, 160, 196, 0.42);
 }
 
 .glass-menu__nav a:hover::after,
@@ -350,14 +350,14 @@ body.theme-dark .glass-menu__nav a[aria-current="page"]::after,
 body.theme-dark .glass-menu__social a[aria-current="page"]::after,
 body:not(.theme-light) .glass-menu__nav a[aria-current="page"]::after,
 body:not(.theme-light) .glass-menu__social a[aria-current="page"]::after {
-  background: linear-gradient(180deg, rgba(241, 245, 249, 0.32), rgba(15, 23, 42, 0.35));
-  opacity: 0.6;
+  background: linear-gradient(180deg, rgba(238, 244, 250, 0.55), rgba(128, 152, 188, 0.4));
+  opacity: 0.65;
 }
 
 .glass-menu__nav a[aria-current="page"]::after,
 .glass-menu__social a[aria-current="page"]::after {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.38), rgba(21, 76, 140, 0.35));
-  opacity: 0.55;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.65), rgba(164, 190, 222, 0.38));
+  opacity: 0.65;
 }
 
 .glass-menu__nav a:focus-visible,
@@ -370,16 +370,16 @@ body.theme-dark .glass-menu__nav a:active,
 body.theme-dark .glass-menu__social a:active,
 body:not(.theme-light) .glass-menu__nav a:active,
 body:not(.theme-light) .glass-menu__social a:active {
-  color: rgba(226, 232, 240, 0.96);
-  border-color: rgba(148, 163, 184, 0.5);
-  text-shadow: 0 1px 0 rgba(2, 6, 23, 0.75);
+  color: #102a4a;
+  border-color: rgba(226, 232, 240, 0.6);
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.45);
 }
 
 .glass-menu__nav a:active,
 .glass-menu__social a:active {
-  color: #e9f3ff;
+  color: #102a4a;
   background: var(--menu-button-surface-pressed);
-  border-color: rgba(255, 255, 255, 0.32);
+  border-color: rgba(255, 255, 255, 0.58);
   box-shadow: var(--menu-button-shadow-pressed);
   transform: none;
 }
@@ -388,18 +388,18 @@ body.theme-dark .glass-menu__nav a[aria-current="page"]:active,
 body.theme-dark .glass-menu__social a[aria-current="page"]:active,
 body:not(.theme-light) .glass-menu__nav a[aria-current="page"]:active,
 body:not(.theme-light) .glass-menu__social a[aria-current="page"]:active {
-  color: rgba(226, 232, 240, 0.98);
-  background: linear-gradient(180deg, rgba(22, 58, 108, 0.98), rgba(9, 32, 74, 0.98));
-  border-color: rgba(148, 163, 184, 0.5);
-  box-shadow: inset 0 2px 6px rgba(3, 20, 46, 0.65);
+  color: #102a4a;
+  background: linear-gradient(180deg, rgba(204, 216, 234, 0.9), rgba(168, 186, 212, 0.88));
+  border-color: rgba(226, 232, 240, 0.62);
+  box-shadow: inset 0 2px 6px rgba(116, 142, 176, 0.48);
 }
 
 .glass-menu__nav a[aria-current="page"]:active,
 .glass-menu__social a[aria-current="page"]:active {
-  color: #f8fbff;
-  background: linear-gradient(180deg, rgba(32, 82, 150, 0.98), rgba(16, 52, 110, 0.98));
-  border-color: rgba(255, 255, 255, 0.36);
-  box-shadow: inset 0 2px 6px rgba(12, 44, 102, 0.62);
+  color: #102a4a;
+  background: linear-gradient(180deg, rgba(212, 226, 244, 0.95), rgba(182, 200, 224, 0.92));
+  border-color: rgba(255, 255, 255, 0.62);
+  box-shadow: inset 0 2px 6px rgba(126, 152, 190, 0.46);
   transform: none;
 }
 

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -56,19 +56,19 @@
     );
   --menu-button-surface-pressed: linear-gradient(
       180deg,
-      rgba(20, 66, 130, 0.92) 0%,
-      rgba(10, 42, 94, 0.92) 100%
+      rgba(224, 234, 246, 0.95) 0%,
+      rgba(192, 210, 232, 0.92) 100%
     ),
     linear-gradient(
       90deg,
-      rgba(9, 38, 86, 0.6) 0%,
-      rgba(18, 56, 108, 0.1) 32%,
-      rgba(4, 18, 56, 0.72) 100%
+      rgba(168, 192, 220, 0.45) 0%,
+      rgba(210, 224, 240, 0.2) 36%,
+      rgba(150, 180, 212, 0.5) 100%
     );
   --menu-button-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16), inset 0 -2px 6px rgba(3, 18, 48, 0.55),
     inset -10px 0 16px rgba(6, 28, 74, 0.45), inset 4px 0 10px rgba(255, 255, 255, 0.18);
-  --menu-button-shadow-pressed: inset 0 1px 0 rgba(6, 20, 52, 0.5), inset 0 -2px 4px rgba(2, 10, 32, 0.7),
-    inset -8px 0 14px rgba(2, 14, 42, 0.55), inset 3px 0 8px rgba(174, 202, 246, 0.24);
+  --menu-button-shadow-pressed: inset 0 1px 0 rgba(255, 255, 255, 0.6), inset 0 -2px 4px rgba(122, 150, 190, 0.45),
+    inset -8px 0 14px rgba(142, 170, 206, 0.35), inset 3px 0 8px rgba(255, 255, 255, 0.3);
   --menu-button-glow: 0 0 18px rgba(30, 88, 156, 0.3);
   --menu-logo-filter: drop-shadow(0 0 18px rgba(255, 255, 255, 0.45))
     drop-shadow(0 12px 28px rgba(6, 24, 56, 0.35));
@@ -130,19 +130,19 @@ body.theme-dark {
     );
   --menu-button-surface-pressed: linear-gradient(
       180deg,
-      rgba(16, 42, 80, 0.94) 0%,
-      rgba(7, 20, 46, 0.94) 100%
+      rgba(210, 222, 238, 0.92) 0%,
+      rgba(176, 194, 216, 0.9) 100%
     ),
     linear-gradient(
       90deg,
-      rgba(8, 24, 56, 0.7) 0%,
-      rgba(14, 34, 68, 0.14) 34%,
-      rgba(3, 12, 32, 0.78) 100%
+      rgba(152, 176, 204, 0.42) 0%,
+      rgba(190, 208, 228, 0.18) 34%,
+      rgba(138, 164, 198, 0.48) 100%
     );
   --menu-button-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.18), inset 0 -2px 6px rgba(2, 8, 26, 0.65),
     inset -10px 0 18px rgba(2, 10, 28, 0.55), inset 4px 0 12px rgba(148, 179, 220, 0.25);
-  --menu-button-shadow-pressed: inset 0 1px 0 rgba(11, 27, 53, 0.55), inset 0 -2px 4px rgba(0, 4, 18, 0.75),
-    inset -8px 0 16px rgba(0, 6, 20, 0.6), inset 3px 0 9px rgba(82, 115, 166, 0.3);
+  --menu-button-shadow-pressed: inset 0 1px 0 rgba(228, 236, 248, 0.6), inset 0 -2px 4px rgba(108, 132, 168, 0.48),
+    inset -8px 0 16px rgba(120, 148, 186, 0.38), inset 3px 0 9px rgba(232, 240, 250, 0.32);
   --menu-button-glow: 0 0 18px rgba(37, 99, 235, 0.35);
   --menu-logo-filter: drop-shadow(0 0 22px rgba(148, 197, 255, 0.55))
     drop-shadow(0 14px 32px rgba(2, 6, 23, 0.55));
@@ -184,22 +184,22 @@ body.theme-dark {
       );
     --menu-button-surface-pressed: linear-gradient(
         160deg,
-        rgba(13, 23, 41, 0.95) 0%,
-        rgba(11, 20, 36, 0.95) 55%,
-        rgba(9, 16, 30, 0.95) 100%
+        rgba(206, 218, 234, 0.88) 0%,
+        rgba(174, 192, 214, 0.86) 60%,
+        rgba(160, 182, 208, 0.84) 100%
       ),
       linear-gradient(
         95deg,
-        rgba(8, 20, 42, 0.75) 0%,
-        rgba(18, 36, 64, 0.2) 32%,
-        rgba(2, 6, 18, 0.82) 100%
+        rgba(150, 174, 204, 0.4) 0%,
+        rgba(188, 206, 228, 0.18) 36%,
+        rgba(136, 162, 198, 0.46) 100%
       );
     --menu-button-shadow: 0 18px 32px rgba(2, 8, 23, 0.65), inset 0 1px 0 rgba(148, 163, 184, 0.25),
       inset 0 -10px 18px rgba(2, 6, 23, 0.6), inset -12px 0 22px rgba(2, 8, 23, 0.55),
       inset 6px 0 14px rgba(148, 179, 220, 0.28);
-    --menu-button-shadow-pressed: 0 10px 18px rgba(2, 6, 23, 0.6), inset 0 6px 12px rgba(11, 27, 53, 0.6),
-      inset 0 -3px 6px rgba(148, 163, 184, 0.2), inset -10px 0 20px rgba(0, 4, 18, 0.65),
-      inset 5px 0 12px rgba(104, 139, 198, 0.32);
+    --menu-button-shadow-pressed: 0 10px 18px rgba(2, 6, 23, 0.6), inset 0 6px 12px rgba(156, 180, 212, 0.55),
+      inset 0 -3px 6px rgba(196, 210, 228, 0.32), inset -10px 0 20px rgba(78, 104, 150, 0.45),
+      inset 5px 0 12px rgba(208, 222, 240, 0.32);
     --menu-button-glow: 0 0 26px rgba(37, 99, 235, 0.45);
     --menu-logo-filter: drop-shadow(0 0 24px rgba(148, 197, 255, 0.6))
       drop-shadow(0 16px 32px rgba(2, 6, 23, 0.62));


### PR DESCRIPTION
## Summary
- refresh the active and pressed glass menu button gradients to a pale silver-blue palette
- adjust hover, active, and selected states to use darker text and brighter highlights for readability
- update theme variables so the translucent plastic styling carries across light and dark modes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deee21ea508325b2823b12886a3b62